### PR TITLE
[WIP]Zeroize sensitive memory in barrier_aes_gcm context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ delay_timer = "0.11"
 as-any = "0.3.1"
 pem = "3.0"
 chrono = "0.4"
+zeroize = { version = "1.4.0", features= ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"


### PR DESCRIPTION
As per: https://github.com/Tongsuo-Project/RustyVault/issues/38, this commit addresses that issue.

This is only one fix, more fixes in other context (for instance, the shamir) are coming up later...