### PR TITLE
Add meta data in Cargo.toml for publishing on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,16 @@
 name = "rusty_vault"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+description = """
+RustyVault is a powerful identity-based secrets management software, providing features such as
+cryptographic key management, encryption as a service, public key cryptography, certificates management, identity credentials
+management and so forth.
+
+RustyVault's RESTful API is designed to be fully compatible with Hashicorp Vault.
+"""
+homepage = "https://github.com/Tongsuo-Project/RustyVault"
+documentation = "https://tongsuo.net/docs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ management and so forth.
 RustyVault's RESTful API is designed to be fully compatible with Hashicorp Vault.
 """
 homepage = "https://github.com/Tongsuo-Project/RustyVault"
-documentation = "https://tongsuo.net/docs"
+documentation = "https://docs.rs/rusty_vault/latest/rusty_vault/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
We have published RustyVault on crates.io as a crate. Some more meta data is needed.