### PR TITLE
Extended the execution flow with custom logic phases.

### DIFF
--- a/src/cli/command/server.rs
+++ b/src/cli/command/server.rs
@@ -124,7 +124,7 @@ pub fn main(config_path: &str) -> Result<(), RvError> {
 
     {
         let mut c = core.write()?;
-        c.config(Arc::clone(&core), Some(config))?;
+        c.config(Arc::clone(&core), Some(&config))?;
     }
 
     let mut http_server = HttpServer::new(move || {

--- a/src/core.rs
+++ b/src/core.rs
@@ -21,7 +21,7 @@ use zeroize::Zeroizing;
 use crate::{
     cli::config::Config,
     errors::RvError,
-    handler::Handler,
+    handler::{AuthHandler, Handler},
     logical::{Backend, Request, Response},
     module_manager::ModuleManager,
     modules::{
@@ -72,6 +72,7 @@ pub struct Core {
     pub mounts: Arc<MountTable>,
     pub router: Arc<Router>,
     pub handlers: RwLock<Vec<Arc<dyn Handler>>>,
+    pub auth_handlers: Arc<RwLock<Vec<Arc<dyn AuthHandler>>>>,
     pub logical_backends: Mutex<HashMap<String, Arc<LogicalBackendNewFunc>>>,
     pub module_manager: ModuleManager,
     pub sealed: bool,
@@ -92,6 +93,7 @@ impl Default for Core {
             mounts: Arc::new(MountTable::new()),
             router: Arc::clone(&router),
             handlers: RwLock::new(vec![router]),
+            auth_handlers: Arc::new(RwLock::new(Vec::new())),
             logical_backends: Mutex::new(HashMap::new()),
             module_manager: ModuleManager::new(),
             sealed: true,
@@ -101,7 +103,7 @@ impl Default for Core {
 }
 
 impl Core {
-    pub fn config(&mut self, core: Arc<RwLock<Core>>, _config: Option<Config>) -> Result<(), RvError> {
+    pub fn config(&mut self, core: Arc<RwLock<Core>>, config: Option<&Config>) -> Result<(), RvError> {
         self.module_manager.set_default_modules(Arc::clone(&core))?;
         self.self_ref = Some(Arc::clone(&core));
 
@@ -124,6 +126,20 @@ impl Core {
         // add credential module: cert
         let cert_module = CertModule::new(self);
         self.module_manager.add_module(Arc::new(RwLock::new(Box::new(cert_module))))?;
+
+        let handlers = self.handlers.read()?;
+        for handler in handlers.iter() {
+            match handler.post_config(Arc::clone(&core), config) {
+                Ok(_) => {
+                    continue;
+                }
+                Err(error) => {
+                    if error != RvError::ErrHandlerDefault {
+                        return Err(error);
+                    }
+                }
+            }
+        }
 
         Ok(())
     }
@@ -252,6 +268,22 @@ impl Core {
     pub fn delete_handler(&self, handler: Arc<dyn Handler>) -> Result<(), RvError> {
         let mut handlers = self.handlers.write()?;
         handlers.retain(|h| h.name() != handler.name());
+        Ok(())
+    }
+
+    pub fn add_auth_handler(&self, auth_handler: Arc<dyn AuthHandler>) -> Result<(), RvError> {
+        let mut auth_handlers = self.auth_handlers.write()?;
+        if let Some(_) = auth_handlers.iter().find(|h| h.name() == auth_handler.name()) {
+            return Err(RvError::ErrCoreHandlerExist);
+        }
+
+        auth_handlers.push(auth_handler);
+        Ok(())
+    }
+
+    pub fn delete_auth_handler(&self, auth_handler: Arc<dyn AuthHandler>) -> Result<(), RvError> {
+        let mut auth_handlers = self.auth_handlers.write()?;
+        auth_handlers.retain(|h| h.name() != auth_handler.name());
         Ok(())
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,13 +6,21 @@
 //! The `Handler` trait should be implemented in other module, such as the `rusty_vault::router`
 //! for instance.
 
+use std::sync::{Arc, RwLock};
+
 use crate::{
+    core::Core,
+    cli::config::Config,
     errors::RvError,
-    logical::{request::Request, response::Response},
+    logical::{request::Request, response::Response, Auth},
 };
 
 pub trait Handler: Send + Sync {
     fn name(&self) -> String;
+
+    fn post_config(&self, _core: Arc<RwLock<Core>>, _config: Option<&Config>) -> Result<(), RvError> {
+        Err(RvError::ErrHandlerDefault)
+    }
 
     fn pre_route(&self, _req: &mut Request) -> Result<Option<Response>, RvError> {
         Err(RvError::ErrHandlerDefault)
@@ -27,6 +35,18 @@ pub trait Handler: Send + Sync {
     }
 
     fn log(&self, _req: &Request, _resp: &Option<Response>) -> Result<(), RvError> {
+        Err(RvError::ErrHandlerDefault)
+    }
+}
+
+pub trait AuthHandler: Send + Sync {
+    fn name(&self) -> String;
+
+    fn pre_auth(&self, _req: &mut Request) -> Result<Option<Auth>, RvError> {
+        Err(RvError::ErrHandlerDefault)
+    }
+
+    fn post_auth(&self, _req: &mut Request) -> Result<(), RvError> {
         Err(RvError::ErrHandlerDefault)
     }
 }


### PR DESCRIPTION
1.Added two phases, pre_auth and post_auth, to the execution flow. Users
  can implement their own token verification logic in pre_auth and their
  own acl logic in post_auth.
2.Add a post_config phase, which will be executed after the configuration
  parsing is completed. Users can implement the auto unseal logic in this
  phase.