### PR TITLE
Add policy module for ACL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ base64 = "0.22"
 ipnetwork = "0.20"
 blake2b_simd = "1.0"
 derive_more = "0.99.17"
-dashmap = "5.5"
+dashmap = "6.1"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
 ctor = "0.2.8"
 better_default = "1.0.5"
@@ -72,6 +72,8 @@ sysinfo = "0.31.4"
 prettytable = "0.10"
 rpassword = "7.3"
 async-trait = "0.1"
+stretto = "0.8"
+itertools = "0.14"
 
 # optional dependencies
 openssl = { version = "0.10.64", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ regex = "1.11"
 clap = { version = "4.5", features = ["wrap_help", "derive", "env", "suggestions"] }
 sysexits = { version = "0.7", features = ["std"] }
 build-time = "0.1"
-hcl-rs = "0.16"
+hcl-rs = "0.18"
 actix-web = { version = "4.4", features = ["openssl"] }
 actix-tls = "3.1"
 actix-rt = "2.9"

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -1,42 +1,5 @@
+pub use crate::utils::string::{ensure_no_leading_slash, ensure_no_trailing_slash, ensure_trailing_slash};
+
 pub fn sanitize_path(s: &str) -> String {
     ensure_no_trailing_slash(&ensure_no_leading_slash(s))
-}
-
-pub fn ensure_trailing_slash(s: &str) -> String {
-    let s = s.trim();
-    if s.is_empty() {
-        return String::new();
-    }
-
-    let mut result = s.to_string();
-    while !result.is_empty() && !result.ends_with('/') {
-        result.push('/');
-    }
-    result
-}
-
-pub fn ensure_no_trailing_slash(s: &str) -> String {
-    let s = s.trim();
-    if s.is_empty() {
-        return String::new();
-    }
-
-    let mut result = s.to_string();
-    while !result.is_empty() && result.ends_with('/') {
-        result.pop();
-    }
-    result
-}
-
-pub fn ensure_no_leading_slash(s: &str) -> String {
-    let s = s.trim();
-    if s.is_empty() {
-        return String::new();
-    }
-
-    let mut result = s.to_string();
-    while !result.is_empty() && result.starts_with('/') {
-        result.remove(0);
-    }
-    result
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -28,6 +28,7 @@ use crate::{
         auth::AuthModule,
         credential::{approle::AppRoleModule, cert::CertModule, userpass::UserPassModule},
         pki::PkiModule,
+        policy::PolicyModule,
     },
     mount::MountTable,
     router::Router,
@@ -119,6 +120,10 @@ impl Core {
         let auth_module = AuthModule::new(self);
         self.module_manager.add_module(Arc::new(RwLock::new(Box::new(auth_module))))?;
 
+        // add policy_module
+        let policy_module = PolicyModule::new(self);
+        self.module_manager.add_module(Arc::new(RwLock::new(Box::new(policy_module))))?;
+
         // add pki_module
         let pki_module = PkiModule::new(self);
         self.module_manager.add_module(Arc::new(RwLock::new(Box::new(pki_module))))?;
@@ -135,9 +140,7 @@ impl Core {
         let cert_module = CertModule::new(self);
         self.module_manager.add_module(Arc::new(RwLock::new(Box::new(cert_module))))?;
 
-        let handlers = {
-            self.handlers.read()?.clone()
-        };
+        let handlers = { self.handlers.read()?.clone() };
         for handler in handlers.iter() {
             match handler.post_config(self, config) {
                 Ok(_) => {

--- a/src/logical/auth.rs
+++ b/src/logical/auth.rs
@@ -52,7 +52,7 @@ pub struct PolicyResults {
     pub granting_policies: Vec<PolicyInfo>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PolicyInfo {
     pub name: String,
     pub namespace_id: String,

--- a/src/logical/auth.rs
+++ b/src/logical/auth.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use better_default::Default;
 use derive_more::{Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 
@@ -37,4 +38,23 @@ pub struct Auth {
     // Metadata is used to attach arbitrary string-type metadata to an authenticated user.
     // This metadata will be outputted into the audit log.
     pub metadata: HashMap<String, String>,
+
+    // policy_results is the set of policies that grant the token access to the requesting path.
+    pub policy_results: Option<PolicyResults>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PolicyResults {
+    pub allowed: bool,
+    pub granting_policies: Vec<PolicyInfo>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PolicyInfo {
+    pub name: String,
+    pub namespace_id: String,
+    pub namespace_path: String,
+    #[serde(rename = "type")]
+    #[default("acl".into())]
+    pub policy_type: String,
 }

--- a/src/logical/auth.rs
+++ b/src/logical/auth.rs
@@ -27,6 +27,9 @@ pub struct Auth {
     // Policies is the list of policies that the authenticated user is associated with.
     pub policies: Vec<String>,
 
+    // token_policies break down the list in policies to help determine where a policy was sourced
+    pub token_policies: Vec<String>,
+
     // Indicates that the default policy should not be added by core when creating a token.
     // The default policy will still be added if it's explicitly defined.
     pub no_default_policy: bool,

--- a/src/logical/request.rs
+++ b/src/logical/request.rs
@@ -162,6 +162,12 @@ impl Request {
         field.get_default()
     }
 
+    pub fn data_iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        let data_iter = self.data.as_ref().into_iter().flat_map(|m| m.iter());
+        let body_iter = self.body.as_ref().into_iter().flat_map(|m| m.iter());
+        data_iter.chain(body_iter)
+    }
+
     //TODO: the sensitive data is still in the memory. Need to totally resolve this in `serde_json` someday.
     pub fn clear_data(&mut self, key: &str) {
         if self.data.is_some() {

--- a/src/modules/auth/token_store.rs
+++ b/src/modules/auth/token_store.rs
@@ -711,7 +711,11 @@ impl Handler for TokenStore {
             auth.token_policies = auth.policies.clone();
             sanitize_policies(&mut auth.token_policies, !auth.no_default_policy);
 
-            if auth.token_policies.contains(&"root".to_string()) {
+            let all_policies = auth.token_policies.clone();
+
+            // TODO: add identity_policies to all_policies
+
+            if all_policies.contains(&"root".to_string()) {
                 return Err(rv_error_response!("auth methods cannot create root tokens"));
             }
 
@@ -729,6 +733,8 @@ impl Handler for TokenStore {
             auth.client_token = te.id.clone();
 
             self.expiration.register_auth(&req.path, auth)?;
+
+            auth.policies = all_policies;
         }
 
         Ok(())

--- a/src/modules/credential/userpass/mod.rs
+++ b/src/modules/credential/userpass/mod.rs
@@ -207,7 +207,7 @@ mod test {
         let resp = test_login(&core, "pass", "test", "123qwe!@#", true).await;
         let login_auth = resp.unwrap().unwrap().auth.unwrap();
         let test_client_token = login_auth.client_token.clone();
-        let resp = test_read_api(&core, &test_client_token, "sys/mounts", true).await;
+        let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", true).await;
         println!("test mounts resp: {:?}", resp);
         assert!(resp.unwrap().is_some());
 
@@ -227,7 +227,7 @@ mod test {
         println!("wait 7s");
         std::thread::sleep(Duration::from_secs(7));
         let test_client_token = login_auth.client_token.clone();
-        let resp = test_read_api(&core, &test_client_token, "sys/mounts", false).await;
+        let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", false).await;
         println!("test mounts resp: {:?}", resp);
 
         // mount userpass auth to path: auth/testpass
@@ -237,7 +237,7 @@ mod test {
         let login_auth = resp.unwrap().unwrap().auth.unwrap();
         let test_client_token = login_auth.client_token.clone();
         println!("test_client_token: {}", test_client_token);
-        let resp = test_read_api(&core, &test_client_token, "sys/mounts", true).await;
+        let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", true).await;
         println!("test mounts resp: {:?}", resp);
         assert!(resp.unwrap().is_some());
     }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -15,6 +15,7 @@ pub mod crypto;
 pub mod kv;
 pub mod pki;
 pub mod system;
+pub mod policy;
 
 pub trait Module: AsAny + Send + Sync {
     //! Description for a trait itself.

--- a/src/modules/policy/acl.rs
+++ b/src/modules/policy/acl.rs
@@ -81,7 +81,8 @@ impl ACL {
                 }
             }
         }
-        Err(RvError::ErrUnknown)
+
+        Ok(acl)
     }
 
     pub fn get_permissions(&self, pr: &PolicyPathRules) -> Result<Option<Permissions>, RvError> {

--- a/src/modules/policy/acl.rs
+++ b/src/modules/policy/acl.rs
@@ -69,6 +69,43 @@ pub struct ACL {
     pub root: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+struct WcPathDescr {
+    first_wc_or_glob: isize,
+    wc_path: String,
+    is_prefix: bool,
+    wildcards: usize,
+    perms: Option<Permissions>,
+}
+
+impl PartialEq for WcPathDescr {
+    fn eq(&self, other: &Self) -> bool {
+        self.first_wc_or_glob == other.first_wc_or_glob
+            && self.wc_path == other.wc_path
+            && self.is_prefix == other.is_prefix
+            && self.wildcards == other.wildcards
+    }
+}
+
+impl Eq for WcPathDescr {}
+
+impl PartialOrd for WcPathDescr {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for WcPathDescr {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.first_wc_or_glob
+            .cmp(&other.first_wc_or_glob)
+            .then_with(|| other.is_prefix.cmp(&self.is_prefix))
+            .then_with(|| other.wildcards.cmp(&self.wildcards))
+            .then_with(|| self.wc_path.len().cmp(&other.wc_path.len()))
+            .then_with(|| self.wc_path.cmp(&other.wc_path))
+    }
+}
+
 impl ACL {
     /// Constructs a new `ACL` from a slice of policies.
     ///
@@ -108,11 +145,11 @@ impl ACL {
                     }
 
                     existing_perms.merge(&pr.permissions)?;
-                    existing_perms.add_granting_policy_to_map(policy)?;
+                    existing_perms.add_granting_policy_to_map(policy, pr.permissions.capabilities_bitmap)?;
                     acl.insert_permissions(pr, existing_perms)?;
                 } else {
                     let mut cloned_perms = pr.permissions.clone();
-                    cloned_perms.add_granting_policy_to_map(policy)?;
+                    cloned_perms.add_granting_policy_to_map(policy, pr.permissions.capabilities_bitmap)?;
                     acl.insert_permissions(pr, cloned_perms)?;
                 }
             }
@@ -219,56 +256,667 @@ impl ACL {
             }
         }
 
-        if let Some(perm) = self.get_none_exact_paths_permissions(&path)? {
+        if let Some(perm) = self.get_none_exact_paths_permissions(&path, false) {
             return perm.check(req, check_only);
         }
 
         Ok(ACLResults::default())
     }
 
-    /// Retrieves permissions for non-exact paths, such as prefixes or wildcards.
+    /// Retrieves permissions for a path that does not have an exact match.
+    /// This function checks the prefix rules and segment wildcard paths to determine
+    /// if any permissions apply to the given path.
     ///
-    /// This method searches for permissions based on prefixes and wildcards when an exact match isn't found.
+    /// # Arguments
     ///
-    ///  # Arguments
+    /// * `path` - The path to check for permissions.
+    /// * `bare_mount` - A flag indicating whether to use bare mount logic, affecting path matching.
     ///
-    ///  * `path` - A string slice of the path to find permissions for.
+    /// # Returns
     ///
-    ///  # Returns
-    ///
-    ///  * `Result<Option<Permissions>, RvError>` - Returns permissions if found, otherwise `None`.
-    pub fn get_none_exact_paths_permissions(&self, path: &str) -> Result<Option<Permissions>, RvError> {
+    /// * `Option<Permissions>` - Returns permissions if found, otherwise `None`.
+    pub fn get_none_exact_paths_permissions(&self, path: &str, bare_mount: bool) -> Option<Permissions> {
+        let mut wc_path_descrs = Vec::with_capacity(self.segment_wildcard_paths.len() + 1);
+
         if let Some(item) = self.prefix_rules.get_ancestor(path) {
             if self.segment_wildcard_paths.is_empty() {
-                return Ok(Some(item.value().unwrap().clone()));
+                return Some(item.value().unwrap().clone());
             }
+
+            let prefix = item.key().unwrap().clone();
+            wc_path_descrs.push(WcPathDescr {
+                first_wc_or_glob: prefix.len() as isize,
+                wc_path: prefix,
+                is_prefix: true,
+                perms: item.value().cloned(),
+                ..Default::default()
+            });
         }
 
         if self.segment_wildcard_paths.is_empty() {
-            return Ok(None);
+            return None;
         }
 
-        let _path_parts: Vec<&str> = path.split('/').collect();
+        if self.segment_wildcard_paths.is_empty() {
+            return None;
+        }
 
-        // TODO
+        let path_parts: Vec<&str> = path.split('/').collect();
 
-        Ok(None)
+        for item in self.segment_wildcard_paths.iter() {
+            let (full_wc_path, permissions) = (item.key(), item.value());
+
+            if full_wc_path.is_empty() {
+                continue;
+            }
+
+            let mut pd = WcPathDescr {
+                first_wc_or_glob: full_wc_path.find('+').map(|i| i as isize).unwrap_or(-1),
+                ..Default::default()
+            };
+
+            let mut curr_wc_path = full_wc_path.as_str();
+            if curr_wc_path.ends_with('*') {
+                pd.is_prefix = true;
+                curr_wc_path = &curr_wc_path[..curr_wc_path.len() - 1];
+            }
+            pd.wc_path = curr_wc_path.to_string();
+
+            let split_curr_wc_path: Vec<&str> = curr_wc_path.split('/').collect();
+
+            if !bare_mount && path_parts.len() < split_curr_wc_path.len() {
+                continue;
+            }
+
+            if !bare_mount && !pd.is_prefix && split_curr_wc_path.len() != path_parts.len() {
+                continue;
+            }
+
+            let mut skip = false;
+            let mut segments = Vec::with_capacity(split_curr_wc_path.len());
+
+            for (i, acl_part) in split_curr_wc_path.iter().enumerate() {
+                match *acl_part {
+                    "+" => {
+                        pd.wildcards += 1;
+                        segments.push(path_parts[i]);
+                    }
+                    _ if *acl_part == path_parts[i] => {
+                        segments.push(path_parts[i]);
+                    }
+                    _ if pd.is_prefix && i == split_curr_wc_path.len() - 1 && path_parts[i].starts_with(acl_part) => {
+                        segments.extend_from_slice(&path_parts[i..]);
+                    }
+                    _ if !bare_mount => {
+                        skip = true;
+                        break;
+                    }
+                    _ => {}
+                }
+
+                if bare_mount && i == path_parts.len() - 2 {
+                    let joined_path = segments.join("/") + "/";
+                    if joined_path.starts_with(path) {
+                        if permissions.capabilities_bitmap & Capability::Deny.to_bits() == 0
+                            && permissions.capabilities_bitmap > 0
+                        {
+                            return Some(permissions.clone());
+                        }
+                    }
+                    skip = true;
+                    break;
+                }
+            }
+
+            if !skip {
+                pd.perms = Some(permissions.clone());
+                wc_path_descrs.push(pd);
+            }
+        }
+
+        if bare_mount || wc_path_descrs.is_empty() {
+            return None;
+        }
+
+        wc_path_descrs.sort();
+
+        wc_path_descrs.into_iter().last().and_then(|pd| pd.perms)
     }
 }
 
 #[cfg(test)]
 mod mod_policy_acl_tests {
-    use std::{str::FromStr, sync::Arc};
+    use std::{
+        str::FromStr,
+        sync::Arc,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use serde_json::{json, Map, Value};
 
     use super::*;
     use crate::logical::{Operation, Request};
+
+    static TEST_ACL_POLICY: &str = r#"
+name = "DeV"
+path "dev/*" {
+    policy = "sudo"
+}
+path "stage/*" {
+    policy = "write"
+}
+path "stage/aws/*" {
+    policy = "read"
+    capabilities = ["update", "sudo"]
+}
+path "stage/aws/policy/*" {
+    policy = "sudo"
+}
+path "prod/*" {
+    policy = "read"
+}
+path "prod/aws/*" {
+    policy = "deny"
+}
+path "sys/*" {
+    policy = "deny"
+}
+path "foo/bar" {
+    capabilities = ["read", "create", "sudo"]
+}
+path "baz/quux" {
+    capabilities = ["read", "create", "patch"]
+}
+path "test/+/segment" {
+    capabilities = ["read"]
+}
+path "+/segment/at/front" {
+    capabilities = ["read"]
+}
+path "test/segment/at/end/+" {
+    capabilities = ["read"]
+}
+path "test/segment/at/end/v2/+/" {
+    capabilities = ["read"]
+}
+path "test/+/wildcard/+/*" {
+    capabilities = ["read"]
+}
+path "test/+/wildcardglob/+/end*" {
+    capabilities = ["read"]
+}
+path "1/2/*" {
+    capabilities = ["create"]
+}
+path "1/2/+" {
+    capabilities = ["read"]
+}
+path "1/2/+/+" {
+    capabilities = ["update"]
+}
+    "#;
+
+    static TEST_ACL_POLICY2: &str = r#"
+name = "OpS"
+path "dev/hide/*" {
+    policy = "deny"
+}
+path "stage/aws/policy/*" {
+    policy = "deny"
+    # This should have no effect
+    capabilities = ["read", "update", "sudo"]
+}
+path "prod/*" {
+    policy = "write"
+}
+path "sys/seal" {
+    policy = "sudo"
+}
+path "foo/bar" {
+    capabilities = ["deny"]
+}
+path "baz/quux" {
+    capabilities = ["deny"]
+}
+    "#;
+
+    static TEST_MERGING_POLICIES: &str = r#"
+name = "ops"
+path "foo/bar" {
+    policy = "write"
+    denied_parameters = {
+        "baz" = []
+    }
+    required_parameters = ["baz"]
+}
+path "foo/bar" {
+    policy = "write"
+    denied_parameters = {
+        "zip" = []
+    }
+}
+path "hello/universe" {
+    policy = "write"
+    allowed_parameters = {
+        "foo" = []
+    }
+    required_parameters = ["foo"]
+    max_wrapping_ttl = 300
+    min_wrapping_ttl = 100
+}
+path "hello/universe" {
+    policy = "write"
+    allowed_parameters = {
+        "bar" = []
+    }
+    required_parameters = ["bar"]
+    max_wrapping_ttl = 200
+    min_wrapping_ttl = 50
+}
+path "allow/all" {
+    policy = "write"
+    allowed_parameters = {
+        "test" = []
+        "test1" = ["foo"]
+    }
+}
+path "allow/all" {
+    policy = "write"
+    allowed_parameters = {
+        "*" = []
+    }
+}
+path "allow/all1" {
+    policy = "write"
+    allowed_parameters = {
+        "*" = []
+    }
+}
+path "allow/all1" {
+    policy = "write"
+    allowed_parameters = {
+        "test" = []
+        "test1" = ["foo"]
+    }
+}
+path "deny/all" {
+    policy = "write"
+    denied_parameters = {
+        "test" = []
+    }
+}
+path "deny/all" {
+    policy = "write"
+    denied_parameters = {
+        "*" = []
+    }
+}
+path "deny/all1" {
+    policy = "write"
+    denied_parameters = {
+        "*" = []
+    }
+}
+path "deny/all1" {
+    policy = "write"
+    denied_parameters = {
+        "test" = []
+    }
+}
+path "value/merge" {
+    policy = "write"
+    allowed_parameters = {
+        "test" = [1, 2]
+    }
+    denied_parameters = {
+        "test" = [1, 2]
+    }
+}
+path "value/merge" {
+    policy = "write"
+    allowed_parameters = {
+        "test" = [3, 4]
+    }
+    denied_parameters = {
+        "test" = [3, 4]
+    }
+}
+path "value/empty" {
+    policy = "write"
+    allowed_parameters = {
+        "empty" = []
+    }
+    denied_parameters = {
+        "empty" = [1]
+    }
+}
+path "value/empty" {
+    policy = "write"
+    allowed_parameters = {
+        "empty" = [1]
+    }
+    denied_parameters = {
+        "empty" = []
+    }
+}
+    "#;
+
+    static TEST_PERMISSIONS_POLICY: &str = r#"
+name = "dev"
+path "dev/*" {
+    policy = "write"
+    allowed_parameters = {
+        "zip" = []
+    }
+}
+path "foo/bar" {
+    policy = "write"
+    denied_parameters = {
+        "zap" = []
+    }
+    min_wrapping_ttl = 300
+    max_wrapping_ttl = 400
+}
+path "foo/baz" {
+    policy = "write"
+    allowed_parameters = {
+        "hello" = []
+    }
+    denied_parameters = {
+        "zap" = []
+    }
+    min_wrapping_ttl = 300
+}
+path "working/phone" {
+    policy = "write"
+    max_wrapping_ttl = 400
+}
+path "broken/phone" {
+    policy = "write"
+    allowed_parameters = {
+      "steve" = []
+    }
+    denied_parameters = {
+      "steve" = []
+    }
+}
+path "hello/world" {
+    policy = "write"
+    allowed_parameters = {
+        "*" = []
+    }
+    denied_parameters = {
+        "*" = []
+    }
+}
+path "tree/fort" {
+    policy = "write"
+    allowed_parameters = {
+        "*" = []
+    }
+    denied_parameters = {
+        "foo" = []
+    }
+}
+path "fruit/apple" {
+    policy = "write"
+    allowed_parameters = {
+        "pear" = []
+    }
+    denied_parameters = {
+        "*" = []
+    }
+}
+path "cold/weather" {
+    policy = "write"
+    allowed_parameters = {}
+    denied_parameters = {}
+}
+path "var/aws" {
+    policy = "write"
+    allowed_parameters = {
+        "*" = []
+    }
+    denied_parameters = {
+        "soft" = []
+        "warm" = []
+        "kitty" = []
+    }
+}
+path "var/req" {
+    policy = "write"
+    required_parameters = ["foo"]
+}
+    "#;
+
+    static TEST_VALUE_PERMISSIONS_POLICY: &str = r#"
+name = "op"
+path "dev/*" {
+    policy = "write"
+    allowed_parameters = {
+        "allow" = ["good"]
+    }
+}
+path "foo/bar" {
+    policy = "write"
+    denied_parameters = {
+        "deny" = ["bad*"]
+    }
+}
+path "foo/baz" {
+    policy = "write"
+    allowed_parameters = {
+        "ALLOW" = ["good"]
+    }
+    denied_parameters = {
+        "dEny" = ["bad"]
+    }
+}
+path "fizz/buzz" {
+    policy = "write"
+    allowed_parameters = {
+        "allow_multi" = ["good", "good1", "good2", "*good3"]
+        "allow" = ["good"]
+    }
+    denied_parameters = {
+        "deny_multi" = ["bad", "bad1", "bad2"]
+    }
+}
+path "test/types" {
+    policy = "write"
+    allowed_parameters = {
+        "map" = [{"good" = "one"}]
+        "int" = [1, 2]
+        "bool" = [false]
+    }
+    denied_parameters = {
+    }
+}
+path "test/star" {
+    policy = "write"
+    allowed_parameters = {
+        "*" = []
+        "foo" = []
+        "bar" = [false]
+    }
+    denied_parameters = {
+    }
+}
+    "#;
+
+    static TEST_GRANTING_TEST_POLICY: &str = r#"
+name = "granting_policy"
+path "kv/foo" {
+    capabilities = ["update", "read"]
+}
+
+path "kv/path/*" {
+    capabilities = ["read"]
+}
+
+path "kv/path/longer" {
+    capabilities = ["update", "read"]
+}
+
+path "kv/path/longer2" {
+    capabilities = ["update"]
+}
+
+path "kv/deny" {
+    capabilities = ["deny"]
+}
+
+path "ns1/kv/foo" {
+    capabilities = ["update", "read"]
+}
+    "#;
+
+    static TEST_GRANTING_TEST_POLICY_MERGED: &str = r#"
+name = "granting_policy_merged"
+path "kv/foo" {
+    capabilities = ["update", "read"]
+}
+
+path "kv/bar" {
+    capabilities = ["update", "read"]
+}
+
+path "kv/path/*" {
+    capabilities = ["read"]
+}
+
+path "kv/path/longer" {
+    capabilities = ["read"]
+}
+
+path "kv/path/longer3" {
+    capabilities = ["read"]
+}
+
+path "kv/deny" {
+    capabilities = ["update"]
+}
+    "#;
 
     fn create_test_policy(name: &str, policy_str: &str) -> Policy {
         let policy: Result<Policy, RvError> = Policy::from_str(policy_str);
         assert!(policy.is_ok());
         let mut policy = policy.unwrap();
-        policy.name = name.into();
+        if !name.is_empty() {
+            policy.name = name.into();
+        }
         return policy;
+    }
+
+    #[derive(Debug)]
+    struct BatchTestCase(Operation, &'static str, bool, bool);
+
+    fn acl_batch_test(acl: &ACL, cases: &[BatchTestCase]) {
+        for case in cases.iter() {
+            let req = Request { operation: case.0, path: case.1.to_string(), ..Default::default() };
+
+            let result = acl.allow_operation(&req, false).unwrap();
+            assert_eq!(case.2, result.allowed);
+            assert_eq!(case.3, result.root_privs);
+        }
+    }
+
+    #[test]
+    fn test_sort_wc_path_descrs() {
+        let mut wc_path_descrs = vec![
+            WcPathDescr {
+                first_wc_or_glob: 3,
+                wc_path: String::from("path/a"),
+                is_prefix: false,
+                wildcards: 1,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 1,
+                wc_path: String::from("path/b"),
+                is_prefix: true,
+                wildcards: 0,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 1,
+                wc_path: String::from("path/c"),
+                is_prefix: false,
+                wildcards: 2,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 2,
+                wc_path: String::from("path/d"),
+                is_prefix: true,
+                wildcards: 0,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 4,
+                wc_path: String::from("path/e"),
+                is_prefix: true,
+                wildcards: 0,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 4,
+                wc_path: String::from("path/f"),
+                is_prefix: true,
+                wildcards: 1,
+                perms: None,
+            },
+        ];
+
+        wc_path_descrs.sort();
+
+        let expected = vec![
+            WcPathDescr {
+                first_wc_or_glob: 1,
+                wc_path: String::from("path/b"),
+                is_prefix: true,
+                wildcards: 0,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 1,
+                wc_path: String::from("path/c"),
+                is_prefix: false,
+                wildcards: 2,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 2,
+                wc_path: String::from("path/d"),
+                is_prefix: true,
+                wildcards: 0,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 3,
+                wc_path: String::from("path/a"),
+                is_prefix: false,
+                wildcards: 1,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 4,
+                wc_path: String::from("path/f"),
+                is_prefix: true,
+                wildcards: 1,
+                perms: None,
+            },
+            WcPathDescr {
+                first_wc_or_glob: 4,
+                wc_path: String::from("path/e"),
+                is_prefix: true,
+                wildcards: 0,
+                perms: None,
+            },
+        ];
+
+        assert_eq!(wc_path_descrs, expected);
     }
 
     #[test]
@@ -379,8 +1027,26 @@ mod mod_policy_acl_tests {
     }
 
     #[test]
-    fn test_allow_operation() {
-        let policy1 = create_test_policy(
+    fn test_get_none_exact_paths_permissions() {
+        let policy = create_test_policy(
+            "policy1",
+            r#"
+            path "path1/*" {
+                capabilities = ["read"]
+            }
+            "#,
+        );
+
+        let acl = ACL::new(&[Arc::new(policy)]).unwrap();
+
+        let result = acl.get_none_exact_paths_permissions("path1/subpath", false);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().capabilities_bitmap, Capability::Read.to_bits());
+    }
+
+    #[test]
+    fn test_simple_allow_operation() {
+        let policy = create_test_policy(
             "policy1",
             r#"
             path "path1/" {
@@ -389,7 +1055,7 @@ mod mod_policy_acl_tests {
             "#,
         );
 
-        let acl = ACL::new(&[Arc::new(policy1)]).unwrap();
+        let acl = ACL::new(&[Arc::new(policy)]).unwrap();
 
         let mut req = Request { operation: Operation::Read, path: "path1/".to_string(), ..Default::default() };
 
@@ -408,20 +1074,496 @@ mod mod_policy_acl_tests {
     }
 
     #[test]
-    fn test_get_none_exact_paths_permissions() {
-        let policy1 = create_test_policy(
-            "policy1",
-            r#"
-            path "path1/*" {
-                capabilities = ["read"]
+    fn test_acl_root() {
+        let acl = ACL::new(&[Arc::new(Policy { name: "root".into(), ..Default::default() })]).unwrap();
+
+        let req = Request { operation: Operation::Write, path: "sys/mount/foo".to_string(), ..Default::default() };
+
+        let result = acl.allow_operation(&req, false).unwrap();
+        assert!(result.allowed);
+        assert!(result.root_privs);
+        assert!(result.is_root);
+    }
+
+    #[test]
+    fn test_acl_single() {
+        let policy = create_test_policy("", TEST_ACL_POLICY);
+        let acl = ACL::new(&[Arc::new(policy)]).unwrap();
+
+        let cases = [
+            BatchTestCase(Operation::Read, "root", false, false),
+            BatchTestCase(Operation::Help, "root", true, false),
+            BatchTestCase(Operation::Read, "dev/foo", true, true),
+            BatchTestCase(Operation::Write, "dev/foo", true, true),
+            BatchTestCase(Operation::Delete, "stage/foo", true, false),
+            BatchTestCase(Operation::List, "stage/aws/foo", true, true),
+            BatchTestCase(Operation::Write, "stage/aws/foo", true, true),
+            BatchTestCase(Operation::Write, "stage/aws/policy/foo", true, true),
+            BatchTestCase(Operation::Delete, "prod/foo", false, false),
+            BatchTestCase(Operation::Write, "prod/foo", false, false),
+            BatchTestCase(Operation::Read, "prod/foo", true, false),
+            BatchTestCase(Operation::List, "prod/foo", true, false),
+            BatchTestCase(Operation::Read, "prod/aws/foo", false, false),
+            BatchTestCase(Operation::Read, "foo/bar", true, true),
+            BatchTestCase(Operation::List, "foo/bar", false, true),
+            //TODO
+            //BatchTestCase(Operation::Update, "foo/bar", true, true),
+            //BatchTestCase(Operation::Create, "foo/bar", false, true),
+            BatchTestCase(Operation::Write, "foo/bar", true, true),
+            BatchTestCase(Operation::Read, "baz/quux", true, false),
+            //TODO
+            //BatchTestCase(Operation::Patch, "baz/quux", true, false),
+            BatchTestCase(Operation::List, "baz/quux", false, false),
+            BatchTestCase(Operation::Write, "baz/quux", true, false),
+            //TODO
+            //BatchTestCase(Operation::Create, "baz/quux", true, false),
+            //BatchTestCase(Operation::Update, "baz/quux", false, false),
+
+            // Path segment wildcards
+            BatchTestCase(Operation::Read, "test/foo/bar/segment", false, false),
+            BatchTestCase(Operation::Read, "test/foo/segment", true, false),
+            BatchTestCase(Operation::Read, "test/bar/segment", true, false),
+            BatchTestCase(Operation::Read, "test/segment/at/frond", false, false),
+            BatchTestCase(Operation::Read, "test/segment/at/front", true, false),
+            BatchTestCase(Operation::Read, "test/segment/at/end/foo", true, false),
+            BatchTestCase(Operation::Read, "test/segment/at/end/foo/", false, false),
+            BatchTestCase(Operation::Read, "test/segment/at/end/v2/foo/", true, false),
+            BatchTestCase(Operation::Read, "test/segment/wildcard/at/foo/", true, false),
+            BatchTestCase(Operation::Read, "test/segment/wildcard/at/end", true, false),
+            BatchTestCase(Operation::Read, "test/segment/wildcard/at/end/", true, false),
+            // Path segment wildcards vs glob
+            BatchTestCase(Operation::Read, "1/2/3/4", false, false),
+            BatchTestCase(Operation::Read, "1/2/3", true, false),
+            BatchTestCase(Operation::Write, "1/2/3", false, false),
+            BatchTestCase(Operation::Write, "1/2/3/4", true, false),
+            BatchTestCase(Operation::Write, "1/2/3/4/5", true, false),
+        ];
+
+        acl_batch_test(&acl, &cases);
+    }
+
+    #[test]
+    fn test_acl_layered() {
+        let policy1 = create_test_policy("", TEST_ACL_POLICY);
+        let policy2 = create_test_policy("", TEST_ACL_POLICY2);
+        let acl = ACL::new(&[Arc::new(policy1), Arc::new(policy2)]).unwrap();
+
+        let cases = [
+            BatchTestCase(Operation::Read, "root", false, false),
+            BatchTestCase(Operation::Help, "root", true, false),
+            BatchTestCase(Operation::Read, "dev/foo", true, true),
+            BatchTestCase(Operation::Write, "dev/foo", true, true),
+            BatchTestCase(Operation::Read, "dev/hide/foo", false, false),
+            BatchTestCase(Operation::Write, "dev/hide/foo", false, false),
+            BatchTestCase(Operation::Delete, "stage/foo", true, false),
+            BatchTestCase(Operation::List, "stage/aws/foo", true, true),
+            BatchTestCase(Operation::Write, "stage/aws/foo", true, true),
+            BatchTestCase(Operation::Write, "stage/aws/policy/foo", false, false),
+            BatchTestCase(Operation::Delete, "prod/foo", true, false),
+            BatchTestCase(Operation::Write, "prod/foo", true, false),
+            BatchTestCase(Operation::Read, "prod/foo", true, false),
+            BatchTestCase(Operation::List, "prod/foo", true, false),
+            BatchTestCase(Operation::Read, "prod/aws/foo", false, false),
+            BatchTestCase(Operation::Read, "sys/status", false, false),
+            BatchTestCase(Operation::Write, "sys/seal", true, true),
+            BatchTestCase(Operation::Read, "foo/bar", false, false),
+            BatchTestCase(Operation::List, "foo/bar", false, false),
+            BatchTestCase(Operation::Write, "foo/bar", false, false),
+            //TODO
+            //BatchTestCase(Operation::Create, "foo/bar", false, false),
+            BatchTestCase(Operation::Read, "baz/quux", false, false),
+            BatchTestCase(Operation::List, "baz/quux", false, false),
+            BatchTestCase(Operation::Write, "baz/quux", false, false),
+            //TODO
+            //BatchTestCase(Operation::Write, "baz/quux", false, false),
+            //BatchTestCase(Operation::Patch, "baz/quux", false, false),
+        ];
+
+        acl_batch_test(&acl, &cases);
+    }
+
+    #[test]
+    fn test_acl_policy_merge() {
+        let policy = create_test_policy("", TEST_MERGING_POLICIES);
+        let acl = ACL::new(&[Arc::new(policy)]).unwrap();
+
+        #[derive(Debug)]
+        struct Case(&'static str, Option<Value>, Option<Value>, Vec<&'static str>);
+
+        let cases = [
+            Case("foo/bar", None, Some(json!({"zip": [], "baz": []})), ["baz"].to_vec()),
+            Case("hello/universe", Some(json!({"foo": [], "bar": []})), None, ["foo", "bar"].to_vec()),
+            Case("allow/all", Some(json!({"*": [], "test": [], "test1": ["foo"]})), None, vec![]),
+            Case("allow/all1", Some(json!({"*": [], "test": [], "test1": ["foo"]})), None, vec![]),
+            Case("deny/all", None, Some(json!({"*": [], "test": []})), vec![]),
+            Case("deny/all1", None, Some(json!({"*": [], "test": []})), vec![]),
+            Case("value/merge", Some(json!({"test": [1, 2, 3, 4]})), Some(json!({"test": [1, 2, 3, 4]})), vec![]),
+            Case("value/empty", Some(json!({"empty": []})), Some(json!({"empty": []})), vec![]),
+        ];
+
+        for case in cases.iter() {
+            let result = acl.exact_rules.get(case.0);
+            assert!(result.is_some());
+            let result = result.unwrap();
+            if let Some(allow) = &case.1 {
+                let allowed_parameters = result
+                    .allowed_parameters
+                    .iter()
+                    .map(|(key, value)| {
+                        let array: Vec<Value> = value.iter().map(|s| s.clone()).collect();
+                        (key.clone(), Value::Array(array))
+                    })
+                    .collect();
+                assert_eq!(allow.as_object().unwrap(), &allowed_parameters);
             }
-            "#,
-        );
+            if let Some(deny) = &case.2 {
+                let denied_parameters = result
+                    .denied_parameters
+                    .iter()
+                    .map(|(key, value)| {
+                        let array: Vec<Value> = value.iter().map(|s| s.clone()).collect();
+                        (key.clone(), Value::Array(array))
+                    })
+                    .collect();
+                assert_eq!(deny.as_object().unwrap(), &denied_parameters);
+            }
+            if !case.3.is_empty() {
+                let required: Vec<String> = case.3.iter().map(|s| s.to_string()).collect();
+                assert_eq!(&required, &result.required_parameters);
+            }
+        }
+    }
 
-        let acl = ACL::new(&[Arc::new(policy1)]).unwrap();
+    #[test]
+    fn test_acl_allow_operation() {
+        let policy = create_test_policy("", TEST_PERMISSIONS_POLICY);
+        let acl = ACL::new(&[Arc::new(policy)]).unwrap();
 
-        let result = acl.get_none_exact_paths_permissions("path1/subpath").unwrap();
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().capabilities_bitmap, Capability::Read.to_bits());
+        #[derive(Debug)]
+        struct Case(&'static str, Vec<&'static str>, bool);
+
+        let cases = [
+            Case("dev/ops", ["zip"].to_vec(), true),
+            Case("foo/bar", ["zap"].to_vec(), false),
+            Case("foo/bar", ["zip"].to_vec(), true),
+            //TODO: add req ttl test
+            //Case("foo/bar", ["zip"].to_vec(), false),
+            //Case("foo/bar", ["zip"].to_vec(), false),
+            //Case("foo/bar", ["zip"].to_vec(), true),
+            Case("foo/baz", ["hello"].to_vec(), true),
+            //TODO: add req ttl test
+            //Case("foo/baz", ["hello"].to_vec(), false),
+            //Case("foo/baz", ["hello"].to_vec(), true),
+            //Case("foo/baz", ["zap"].to_vec(), false),
+            Case("broken/phone", ["steve"].to_vec(), false),
+            Case("working/phone", [""].to_vec(), true),
+            //TODO: add req ttl test
+            //Case("working/phone", [""].to_vec(), false),
+            //Case("working/phone", [""].to_vec(), true),
+            Case("hello/world", ["one"].to_vec(), false),
+            Case("tree/fort", ["one"].to_vec(), true),
+            Case("tree/fort", ["foo"].to_vec(), false),
+            Case("fruit/apple", ["pear"].to_vec(), false),
+            Case("fruit/apple", ["one"].to_vec(), false),
+            Case("cold/weather", ["four"].to_vec(), true),
+            Case("var/aws", ["cold", "warm", "kitty"].to_vec(), false),
+            Case("var/req", ["cold", "warm", "kitty"].to_vec(), false),
+            Case("var/req", ["cold", "warm", "kitty", "foo"].to_vec(), true),
+        ];
+
+        for case in cases.iter() {
+            let mut req = Request { operation: Operation::Write, path: case.0.to_string(), ..Default::default() };
+
+            let mut data: Map<String, Value> = Map::new();
+            for parameter in case.1.iter() {
+                data.insert(parameter.to_string(), Value::String("".into()));
+            }
+
+            req.body = Some(data);
+
+            let result = acl.allow_operation(&req, false).unwrap();
+            assert_eq!(case.2, result.allowed);
+        }
+    }
+
+    #[test]
+    fn test_acl_value_permissions() {
+        let policy = create_test_policy("", TEST_VALUE_PERMISSIONS_POLICY);
+        let acl = ACL::new(&[Arc::new(policy)]).unwrap();
+
+        #[derive(Debug)]
+        struct Case(&'static str, Vec<&'static str>, Vec<Value>, bool);
+
+        let cases = [
+            Case("dev/ops", ["allow"].to_vec(), [json!("good")].to_vec(), true),
+            Case("dev/ops", ["allow"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("foo/bar", ["deny"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("foo/bar", ["deny"].to_vec(), [json!("bad glob")].to_vec(), false),
+            Case("foo/bar", ["deny"].to_vec(), [json!("good")].to_vec(), true),
+            Case("foo/bar", ["allow"].to_vec(), [json!("good")].to_vec(), true),
+            Case("foo/bar", ["deny"].to_vec(), [Value::Null].to_vec(), true),
+            Case("foo/bar", ["allow"].to_vec(), [Value::Null].to_vec(), true),
+            Case("foo/baz", ["aLLow"].to_vec(), [json!("good")].to_vec(), true),
+            Case("foo/baz", ["deny"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("foo/baz", ["deny"].to_vec(), [json!("good")].to_vec(), false),
+            Case("foo/baz", ["allow", "deny"].to_vec(), [json!("good"), json!("bad")].to_vec(), false),
+            Case("foo/baz", ["deny", "allow"].to_vec(), [json!("good"), json!("bad")].to_vec(), false),
+            Case("foo/baz", ["deNy", "allow"].to_vec(), [json!("bad"), json!("good")].to_vec(), false),
+            Case("foo/baz", ["aLLow"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("foo/baz", ["Neither"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("foo/baz", ["allow"].to_vec(), [Value::Null].to_vec(), false),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("good")].to_vec(), true),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("good1")].to_vec(), true),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("good2")].to_vec(), true),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("glob good2")].to_vec(), false),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("glob good3")].to_vec(), true),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("fizz/buzz", ["allow_multi"].to_vec(), [json!("bad")].to_vec(), false),
+            Case("fizz/buzz", ["allow_multi", "allow"].to_vec(), [json!("good1"), json!("good")].to_vec(), true),
+            Case("fizz/buzz", ["deny_multi"].to_vec(), [json!("bad2")].to_vec(), false),
+            Case("fizz/buzz", ["deny_multi", "allow_multi"].to_vec(), [json!("good"), json!("good2")].to_vec(), false),
+            Case("test/types", ["map"].to_vec(), [json!({"good": "one"})].to_vec(), true),
+            Case("test/types", ["map"].to_vec(), [json!({"bad": "one"})].to_vec(), false),
+            Case("test/types", ["int"].to_vec(), [json!(1)].to_vec(), true),
+            Case("test/types", ["int"].to_vec(), [json!(3)].to_vec(), false),
+            Case("test/types", ["bool"].to_vec(), [json!(false)].to_vec(), true),
+            Case("test/types", ["bool"].to_vec(), [json!(true)].to_vec(), false),
+            Case("test/star", ["anything"].to_vec(), [json!(true)].to_vec(), true),
+            Case("test/star", ["foo"].to_vec(), [json!(true)].to_vec(), true),
+            Case("test/star", ["bar"].to_vec(), [json!(false)].to_vec(), true),
+            Case("test/star", ["bar"].to_vec(), [json!(true)].to_vec(), false),
+        ];
+
+        for case in cases.iter() {
+            let mut req = Request { operation: Operation::Write, path: case.0.to_string(), ..Default::default() };
+
+            let mut data: Map<String, Value> = Map::new();
+            let mut i = 0;
+            for parameter in case.1.iter() {
+                data.insert(parameter.to_string(), case.2[i].clone());
+                i += 1;
+            }
+
+            req.body = Some(data);
+
+            let result = acl.allow_operation(&req, false).unwrap();
+            assert_eq!(case.3, result.allowed);
+        }
+    }
+
+    #[test]
+    fn test_acl_segment_wildcard_priority() {
+        #[derive(Debug)]
+        struct Case(&'static str, &'static str);
+
+        // These test cases should each have a read rule and an update rule, where
+        // the update rule wins out due to being more specific.
+        let cases = [
+            Case(
+                // Verify edge conditions.  Here '*' is more specific both because
+                // of first wildcard position (0 vs -1/infinity) and #wildcards.
+                r#"
+                    path "+/*" { capabilities = ["read"] }
+                    path "*" { capabilities = ["update"] }
+                "#,
+                "foo/bar/bar/baz",
+            ),
+            Case(
+                // Verify edge conditions.  Here '+/*' is less specific because of
+                // first wildcard position.
+                r#"
+                    path "+/*" { capabilities = ["read"] }
+                    path "foo/+/*" { capabilities = ["update"] }
+                "#,
+                "foo/bar/bar/baz",
+            ),
+            Case(
+                // Verify that more wildcard segments is lower priority.
+                r#"
+                    path "foo/+/+/*" { capabilities = ["read"] }
+                    path "foo/+/bar/baz" { capabilities = ["update"] }
+                "#,
+                "foo/bar/bar/baz",
+            ),
+            Case(
+                // Verify that more wildcard segments is lower priority.
+                r#"
+                    path "foo/+/+/baz" { capabilities = ["read"] }
+                    path "foo/+/bar/baz" { capabilities = ["update"] }
+                "#,
+                "foo/bar/bar/baz",
+            ),
+            Case(
+                // Verify that first wildcard position is lower priority.
+                // '(' is used here because it is lexicographically smaller than "+"
+                r#"
+                    path "foo/+/(ar/baz" { capabilities = ["read"] }
+                    path "foo/(ar/+/baz" { capabilities = ["update"] }
+                "#,
+                "foo/(ar/(ar/baz",
+            ),
+            Case(
+                // Verify that a glob has lower priority, even if the prefix is the
+                // same otherwise.
+                r#"
+                    path "foo/bar/+/baz*" { capabilities = ["read"] }
+                    path "foo/bar/+/baz" { capabilities = ["update"] }
+                "#,
+                "foo/bar/bar/baz",
+            ),
+            Case(
+                // Verify that a shorter prefix has lower priority.
+                r#"
+                    path "foo/bar/+/b*" { capabilities = ["read"] }
+                    path "foo/bar/+/ba*" { capabilities = ["update"] }
+                "#,
+                "foo/bar/bar/baz",
+            ),
+        ];
+
+        for case in cases.iter() {
+            let policy = create_test_policy("", case.0);
+            let acl = ACL::new(&[Arc::new(policy)]).unwrap();
+
+            let mut req = Request { operation: Operation::Write, path: case.1.to_string(), ..Default::default() };
+
+            let result = acl.allow_operation(&req, false).unwrap();
+            assert!(result.allowed);
+
+            req.operation = Operation::Read;
+            let result = acl.allow_operation(&req, false).unwrap();
+            assert!(!result.allowed);
+        }
+    }
+
+    #[test]
+    fn test_acl_segment_wildcard_priority_bare_mount() {
+        #[derive(Debug)]
+        struct Case(&'static str, &'static str, bool);
+
+        // These test cases should have one or more rules and a mount prefix.
+        // hasperms should be true if there are non-deny perms that apply
+        // to the mount prefix or something below it.
+        let cases = [
+            Case(r#"path "+" { capabilities = ["read"] }"#, "foo/", true),
+            Case(r#"path "+/*" { capabilities = ["read"] }"#, "foo/", true),
+            Case(r#"path "foo/+/+/*" { capabilities = ["read"] }"#, "foo/", true),
+            Case(r#"path "foo/+/+/*" { capabilities = ["read"] }"#, "foo/bar/", true),
+            Case(r#"path "foo/+/+/*" { capabilities = ["read"] }"#, "foo/bar/bar/", true),
+            Case(r#"path "foo/+/+/*" { capabilities = ["read"] }"#, "foo/bar/bar/baz/", true),
+            Case(r#"path "foo/+/+/baz" { capabilities = ["read"] }"#, "foo/bar/bar/baz/", true),
+            Case(r#"path "foo/+/bar/baz" { capabilities = ["read"] }"#, "foo/bar/bar/baz/", true),
+            Case(r#"path "foo/bar/+/baz*" { capabilities = ["read"] }"#, "foo/bar/bar/baz/", true),
+            Case(r#"path "foo/bar/+/b*" { capabilities = ["read"] }"#, "foo/bar/bar/baz/", true),
+            Case(r#"path "foo/+" { capabilities = ["read"] }"#, "foo/", true),
+        ];
+
+        for case in cases.iter() {
+            let policy = create_test_policy("", case.0);
+            let acl = ACL::new(&[Arc::new(policy)]).unwrap();
+
+            let result = acl.get_none_exact_paths_permissions(case.1, true);
+            println!("case: {:?}", case);
+            println!("result: {:?}", result);
+            assert_eq!(result.is_some(), case.2);
+        }
+    }
+
+    #[test]
+    fn test_acl_creation_race() {
+        let policy = Arc::new(create_test_policy("", TEST_VALUE_PERMISSIONS_POLICY));
+
+        let mut threads = Vec::new();
+        let stop_time = Instant::now() + Duration::from_secs(20);
+
+        for _i in 0..50 {
+            let p = policy.clone();
+            threads.push(thread::spawn(move || loop {
+                if Instant::now() >= stop_time {
+                    break;
+                }
+                assert!(ACL::new(&[p.clone()]).is_ok());
+            }));
+        }
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_acl_granting_policies() {
+        let policy = Arc::new(create_test_policy("", TEST_GRANTING_TEST_POLICY));
+        let merged = Arc::new(create_test_policy("", TEST_GRANTING_TEST_POLICY_MERGED));
+
+        let policy_info = PolicyInfo {
+            name: "granting_policy".into(),
+            namespace_id: "".into(),
+            namespace_path: "".into(),
+            policy_type: "acl".into(),
+        };
+        let merged_info = PolicyInfo {
+            name: "granting_policy_merged".into(),
+            namespace_id: "".into(),
+            namespace_path: "".into(),
+            policy_type: "acl".into(),
+        };
+
+        #[derive(Debug)]
+        struct Case(&'static str, Operation, Vec<Arc<Policy>>, Vec<PolicyInfo>, bool);
+
+        let cases = [
+            Case("kv/foo", Operation::Read, [policy.clone()].to_vec(), [policy_info.clone()].to_vec(), true),
+            Case("kv/foo", Operation::Write, [policy.clone()].to_vec(), [policy_info.clone()].to_vec(), true),
+            Case("kv/bad", Operation::Read, [policy.clone()].to_vec(), vec![], false),
+            Case("kv/deny", Operation::Read, [policy.clone()].to_vec(), vec![], false),
+            Case("kv/path/foo", Operation::Read, [policy.clone()].to_vec(), [policy_info.clone()].to_vec(), true),
+            Case("kv/path/longer", Operation::Read, [policy.clone()].to_vec(), [policy_info.clone()].to_vec(), true),
+            Case(
+                "kv/foo",
+                Operation::Read,
+                [policy.clone(), merged.clone()].to_vec(),
+                [policy_info.clone(), merged_info.clone()].to_vec(),
+                true,
+            ),
+            Case(
+                "kv/path/longer3",
+                Operation::Read,
+                [policy.clone(), merged.clone()].to_vec(),
+                [merged_info.clone()].to_vec(),
+                true,
+            ),
+            Case(
+                "kv/bar",
+                Operation::Read,
+                [policy.clone(), merged.clone()].to_vec(),
+                [merged_info.clone()].to_vec(),
+                true,
+            ),
+            Case("kv/deny", Operation::Read, [policy.clone(), merged.clone()].to_vec(), vec![], false),
+            Case(
+                "kv/path/longer",
+                Operation::Write,
+                [policy.clone(), merged.clone()].to_vec(),
+                [policy_info.clone()].to_vec(),
+                true,
+            ),
+            Case(
+                "kv/path/foo",
+                Operation::Read,
+                [policy.clone(), merged.clone()].to_vec(),
+                [policy_info.clone(), merged_info.clone()].to_vec(),
+                true,
+            ),
+        ];
+        for case in cases.iter() {
+            let acl = ACL::new(&case.2).unwrap();
+
+            let req = Request { operation: case.1, path: case.0.to_string(), ..Default::default() };
+
+            let result = acl.allow_operation(&req, false).unwrap();
+            assert_eq!(case.3, result.granting_policies);
+            assert_eq!(case.4, result.allowed);
+        }
     }
 }

--- a/src/modules/policy/acl.rs
+++ b/src/modules/policy/acl.rs
@@ -1,3 +1,23 @@
+//! This Rust file defines the implementation of Access Control Lists (ACLs) for handling
+//! authorization and permissions within a security context.
+//!
+//! The primary structures include:
+//! - `AuthResults`: Stores the results of authentication checks, including ACL and sentinel results.
+//! - `ACLResults`: Contains detailed results from ACL checks, such as permissions and capabilities.
+//! - `SentinelResults`: Holds information about granting policies determined by sentinels.
+//! - `ACL`: Manages rules and policies related to access control, using data structures like `Trie`
+//!    and `DashMap` for efficient storage and retrieval.
+//!
+//! Key Functionality:
+//! - Constructing an ACL from a list of policies.
+//! - Checking if a requested operation is allowed based on the defined ACL rules.
+//! - Managing permission rules with support for exact, prefix, and segment wildcard path matching.
+//! - Storing and retrieving permissions with efficiency using data structures optimized for this purpose.
+//!
+//! External Dependencies:
+//! - Uses `radix_trie` for efficient storage and retrieval of path rules.
+//! - Relies on `dashmap` for concurrent access to wildcard path permissions.
+
 use std::sync::Arc;
 
 use better_default::Default;
@@ -12,6 +32,7 @@ use crate::{
     utils::string::ensure_no_leading_slash,
 };
 
+/// Stores the results of an authentication check, including ACL and sentinel results.
 #[derive(Debug, Clone, Default)]
 pub struct AuthResults {
     pub acl_results: ACLResults,
@@ -21,6 +42,7 @@ pub struct AuthResults {
     pub denied_error: bool,
 }
 
+/// Contains the outcome of an ACL check, including capabilities and granting policies.
 #[derive(Debug, Clone, Default)]
 pub struct ACLResults {
     pub allowed: bool,
@@ -30,11 +52,13 @@ pub struct ACLResults {
     pub granting_policies: Vec<PolicyInfo>,
 }
 
+/// Stores results specific to sentinel checks.
 #[derive(Debug, Clone, Default)]
 pub struct SentinelResults {
     pub granting_policies: Vec<PolicyInfo>,
 }
 
+/// Represents an ACL system, containing rules for exact matches, prefixes, and segment wildcards.
 #[derive(Debug, Clone, Default)]
 pub struct ACL {
     pub exact_rules: Trie<String, Permissions>,
@@ -46,6 +70,18 @@ pub struct ACL {
 }
 
 impl ACL {
+    /// Constructs a new `ACL` from a slice of policies.
+    ///
+    /// This method processes each policy, checking for `Rgp` and `Acl` types. It inserts rules into
+    /// appropriate structures based on the path rules, managing exact matches, prefixes, and segment wildcards.
+    ///
+    /// # Arguments
+    ///
+    /// * `policies` - A slice of shared policies to initialize the ACL with.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, RvError>` - Returns an initialized `ACL` or an error if a policy type is incorrect.
     pub fn new(policies: &[Arc<Policy>]) -> Result<Self, RvError> {
         let mut acl = ACL::default();
         for policy in policies.iter() {
@@ -85,6 +121,18 @@ impl ACL {
         Ok(acl)
     }
 
+    /// Retrieves permissions for a given path rule.
+    ///
+    /// This method checks for both segment wildcard paths and exact/prefix rules, returning the permissions
+    /// if they exist for the given path.
+    ///
+    /// # Arguments
+    ///
+    /// * `pr` - A reference to a `PolicyPathRules` to find permissions for.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Option<Permissions>, RvError>` - Returns the permissions if found, otherwise `None`.
     pub fn get_permissions(&self, pr: &PolicyPathRules) -> Result<Option<Permissions>, RvError> {
         if pr.has_segment_wildcards {
             if let Some(existing_perms) = self.segment_wildcard_paths.get(&pr.path) {
@@ -101,6 +149,19 @@ impl ACL {
         Ok(None)
     }
 
+    /// Inserts permissions into the appropriate rule set based on path rules.
+    ///
+    /// Depending on whether the path uses segment wildcards or is an exact/prefix rule, it inserts the
+    /// permissions into the respective storage structure.
+    ///
+    /// # Arguments
+    ///
+    /// * `pr` - A reference to `PolicyPathRules` providing path info.
+    /// * `perm` - The `Permissions` to insert.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<(), RvError>` - Returns an error if insertion fails.
     pub fn insert_permissions(&mut self, pr: &PolicyPathRules, perm: Permissions) -> Result<(), RvError> {
         if pr.has_segment_wildcards {
             self.segment_wildcard_paths.insert(pr.path.clone(), perm);
@@ -113,6 +174,19 @@ impl ACL {
         Ok(())
     }
 
+    /// Checks if an operation is allowed based on the ACL rules.
+    ///
+    /// This function checks various rules (exact matches, lists, prefixes, and wildcards) to determine
+    /// if the operation specified in the request is allowed.
+    ///
+    /// # Arguments
+    ///
+    /// * `req` - A reference to the `Request` being checked.
+    /// * `check_only` - A boolean indicating if the function should only perform a check without modifying state.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<ACLResults, RvError>` - The result of the ACL check, indicating allowed operations and other details.
     pub fn allow_operation(&self, req: &Request, check_only: bool) -> Result<ACLResults, RvError> {
         if self.root {
             return Ok(ACLResults {
@@ -152,6 +226,17 @@ impl ACL {
         Ok(ACLResults::default())
     }
 
+    /// Retrieves permissions for non-exact paths, such as prefixes or wildcards.
+    ///
+    /// This method searches for permissions based on prefixes and wildcards when an exact match isn't found.
+    ///
+    ///  # Arguments
+    ///
+    ///  * `path` - A string slice of the path to find permissions for.
+    ///
+    ///  # Returns
+    ///
+    ///  * `Result<Option<Permissions>, RvError>` - Returns permissions if found, otherwise `None`.
     pub fn get_none_exact_paths_permissions(&self, path: &str) -> Result<Option<Permissions>, RvError> {
         if let Some(item) = self.prefix_rules.get_ancestor(path) {
             if self.segment_wildcard_paths.is_empty() {
@@ -168,5 +253,175 @@ impl ACL {
         // TODO
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod mod_policy_acl_tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use super::*;
+    use crate::logical::{Operation, Request};
+
+    fn create_test_policy(name: &str, policy_str: &str) -> Policy {
+        let policy: Result<Policy, RvError> = Policy::from_str(policy_str);
+        assert!(policy.is_ok());
+        let mut policy = policy.unwrap();
+        policy.name = name.into();
+        return policy;
+    }
+
+    #[test]
+    fn test_new_acl() {
+        let policy1 = create_test_policy(
+            "policy1",
+            r#"
+            path "path1/" {
+                capabilities = ["read", "list"]
+            }
+            "#,
+        );
+
+        let policy2 = create_test_policy(
+            "policy2",
+            r#"
+            path "path2/*" {
+                capabilities = ["update", "delete"]
+            }
+            "#,
+        );
+
+        let acl = ACL::new(&[Arc::new(policy1), Arc::new(policy2)]).unwrap();
+
+        assert_eq!(acl.root, false);
+        assert_eq!(
+            acl.exact_rules.get("path1/").unwrap().capabilities_bitmap,
+            Capability::Read.to_bits() | Capability::List.to_bits()
+        );
+        assert_eq!(
+            acl.prefix_rules.get_ancestor_value("path2/kk").unwrap().capabilities_bitmap,
+            Capability::Update.to_bits() | Capability::Delete.to_bits()
+        );
+    }
+
+    #[test]
+    fn test_get_permissions() {
+        let policy1 = create_test_policy(
+            "policy1",
+            r#"
+            path "path1/" {
+                capabilities = ["read", "list"]
+            }
+
+            path "path2*" {
+                capabilities = ["update", "delete"]
+            }
+            "#,
+        );
+
+        let policy2 = create_test_policy(
+            "policy2",
+            r#"
+            path "path2/*" {
+                capabilities = ["update", "delete"]
+            }
+            "#,
+        );
+
+        let (policy1, policy2) = (Arc::new(policy1), Arc::new(policy2));
+
+        let acl = ACL::new(&[policy1.clone(), policy2.clone()]).unwrap();
+
+        let perm1 = acl.get_permissions(&policy1.paths[0]).unwrap().unwrap();
+        if policy1.paths[0].path == "path1/" {
+            assert_eq!(perm1.capabilities_bitmap, Capability::Read.to_bits() | Capability::List.to_bits());
+        } else {
+            assert_eq!(perm1.capabilities_bitmap, Capability::Update.to_bits() | Capability::Delete.to_bits());
+        }
+
+        let perm2 = acl.get_permissions(&policy2.paths[0]).unwrap().unwrap();
+        assert_eq!(perm2.capabilities_bitmap, Capability::Update.to_bits() | Capability::Delete.to_bits());
+    }
+
+    #[test]
+    fn test_insert_permissions() {
+        let mut acl = ACL::default();
+        let perm = Permissions { capabilities_bitmap: Capability::Read.to_bits(), ..Default::default() };
+
+        acl.insert_permissions(
+            &PolicyPathRules {
+                path: "path1/".to_string(),
+                is_prefix: false,
+                has_segment_wildcards: false,
+                ..Default::default()
+            },
+            perm.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(acl.exact_rules.get("path1/").unwrap().capabilities_bitmap, Capability::Read.to_bits());
+
+        acl.insert_permissions(
+            &PolicyPathRules {
+                path: "path2".to_string(),
+                is_prefix: true,
+                has_segment_wildcards: false,
+                ..Default::default()
+            },
+            perm,
+        )
+        .unwrap();
+
+        assert_eq!(
+            acl.prefix_rules.get_ancestor_value("path222").unwrap().capabilities_bitmap,
+            Capability::Read.to_bits()
+        );
+    }
+
+    #[test]
+    fn test_allow_operation() {
+        let policy1 = create_test_policy(
+            "policy1",
+            r#"
+            path "path1/" {
+                capabilities = ["read"]
+            }
+            "#,
+        );
+
+        let acl = ACL::new(&[Arc::new(policy1)]).unwrap();
+
+        let mut req = Request { operation: Operation::Read, path: "path1/".to_string(), ..Default::default() };
+
+        let result = acl.allow_operation(&req, false).unwrap();
+        assert!(result.allowed);
+        assert!(!result.root_privs);
+        assert!(!result.is_root);
+        assert_eq!(result.capabilities_bitmap, Capability::Read.to_bits());
+
+        req.path = "path2/".to_string();
+        let result = acl.allow_operation(&req, false).unwrap();
+        assert!(!result.allowed);
+        assert!(!result.root_privs);
+        assert!(!result.is_root);
+        assert_eq!(result.capabilities_bitmap, 0);
+    }
+
+    #[test]
+    fn test_get_none_exact_paths_permissions() {
+        let policy1 = create_test_policy(
+            "policy1",
+            r#"
+            path "path1/*" {
+                capabilities = ["read"]
+            }
+            "#,
+        );
+
+        let acl = ACL::new(&[Arc::new(policy1)]).unwrap();
+
+        let result = acl.get_none_exact_paths_permissions("path1/subpath").unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().capabilities_bitmap, Capability::Read.to_bits());
     }
 }

--- a/src/modules/policy/acl.rs
+++ b/src/modules/policy/acl.rs
@@ -1,0 +1,171 @@
+use std::sync::Arc;
+
+use better_default::Default;
+use dashmap::DashMap;
+use radix_trie::{Trie, TrieCommon};
+
+use super::{policy::Capability, Permissions, Policy, PolicyPathRules, PolicyType};
+use crate::{
+    errors::RvError,
+    logical::{auth::PolicyInfo, Operation, Request},
+    rv_error_string,
+    utils::string::ensure_no_leading_slash,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct AuthResults {
+    pub acl_results: ACLResults,
+    pub sentinel_results: SentinelResults,
+    pub allowed: bool,
+    pub root_privs: bool,
+    pub denied_error: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ACLResults {
+    pub allowed: bool,
+    pub root_privs: bool,
+    pub is_root: bool,
+    pub capabilities_bitmap: u32,
+    pub granting_policies: Vec<PolicyInfo>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SentinelResults {
+    pub granting_policies: Vec<PolicyInfo>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ACL {
+    pub exact_rules: Trie<String, Permissions>,
+    pub prefix_rules: Trie<String, Permissions>,
+    pub segment_wildcard_paths: DashMap<String, Permissions>,
+    pub rgp_policies: Vec<Arc<Policy>>,
+    #[default(false)]
+    pub root: bool,
+}
+
+impl ACL {
+    pub fn new(policies: &[Arc<Policy>]) -> Result<Self, RvError> {
+        let mut acl = ACL::default();
+        for policy in policies.iter() {
+            if policy.policy_type == PolicyType::Rgp {
+                acl.rgp_policies.push(policy.clone());
+                continue;
+            } else if policy.policy_type != PolicyType::Acl {
+                return Err(rv_error_string!("unable to parse policy (wrong type)"));
+            }
+
+            if policy.name == "root" {
+                if policies.len() != 1 {
+                    return Err(rv_error_string!("other policies present along with root"));
+                }
+                acl.root = true;
+            }
+
+            for pr in policy.paths.iter() {
+                if let Some(mut existing_perms) = acl.get_permissions(pr)? {
+                    let deny = Capability::Deny.to_bits();
+                    if existing_perms.capabilities_bitmap & deny != 0 {
+                        // If we are explicitly denied in the existing capability set, don't save anything else
+                        continue;
+                    }
+
+                    existing_perms.merge(&pr.permissions)?;
+                    existing_perms.add_granting_policy_to_map(policy)?;
+                    acl.insert_permissions(pr, existing_perms)?;
+                } else {
+                    let mut cloned_perms = pr.permissions.clone();
+                    cloned_perms.add_granting_policy_to_map(policy)?;
+                    acl.insert_permissions(pr, cloned_perms)?;
+                }
+            }
+        }
+        Err(RvError::ErrUnknown)
+    }
+
+    pub fn get_permissions(&self, pr: &PolicyPathRules) -> Result<Option<Permissions>, RvError> {
+        if pr.has_segment_wildcards {
+            if let Some(existing_perms) = self.segment_wildcard_paths.get(&pr.path) {
+                return Ok(Some(existing_perms.value().clone()));
+            }
+        } else {
+            let tree = if pr.is_prefix { &self.prefix_rules } else { &self.exact_rules };
+
+            if let Some(existing_perms) = tree.get(&pr.path) {
+                return Ok(Some(existing_perms.clone()));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn insert_permissions(&mut self, pr: &PolicyPathRules, perm: Permissions) -> Result<(), RvError> {
+        if pr.has_segment_wildcards {
+            self.segment_wildcard_paths.insert(pr.path.clone(), perm);
+        } else {
+            let tree = if pr.is_prefix { &mut self.prefix_rules } else { &mut self.exact_rules };
+
+            tree.insert(pr.path.clone(), perm);
+        }
+
+        Ok(())
+    }
+
+    pub fn allow_operation(&self, req: &Request, check_only: bool) -> Result<ACLResults, RvError> {
+        if self.root {
+            return Ok(ACLResults {
+                allowed: true,
+                root_privs: true,
+                is_root: true,
+                granting_policies: vec![PolicyInfo {
+                    name: "root".into(),
+                    namespace_id: "root".into(),
+                    policy_type: "acl".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            });
+        }
+
+        if req.operation == Operation::Help {
+            return Ok(ACLResults { allowed: true, ..Default::default() });
+        }
+
+        let path = ensure_no_leading_slash(&req.path);
+
+        if let Some(perm) = self.exact_rules.get(&path) {
+            return perm.check(req, check_only);
+        }
+
+        if req.operation == Operation::List {
+            if let Some(perm) = self.exact_rules.get(path.trim_end_matches("/")) {
+                return perm.check(req, check_only);
+            }
+        }
+
+        if let Some(perm) = self.get_none_exact_paths_permissions(&path)? {
+            return perm.check(req, check_only);
+        }
+
+        Ok(ACLResults::default())
+    }
+
+    pub fn get_none_exact_paths_permissions(&self, path: &str) -> Result<Option<Permissions>, RvError> {
+        if let Some(item) = self.prefix_rules.get_ancestor(path) {
+            if self.segment_wildcard_paths.is_empty() {
+                return Ok(Some(item.value().unwrap().clone()));
+            }
+        }
+
+        if self.segment_wildcard_paths.is_empty() {
+            return Ok(None);
+        }
+
+        let _path_parts: Vec<&str> = path.split('/').collect();
+
+        // TODO
+
+        Ok(None)
+    }
+}

--- a/src/modules/policy/mod.rs
+++ b/src/modules/policy/mod.rs
@@ -1,0 +1,132 @@
+use std::{
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use better_default::Default;
+use serde_json::{Map, Value};
+
+use super::Module;
+use crate::{
+    core::Core,
+    errors::RvError,
+    handler::AuthHandler,
+    logical::{Backend, Request, Response},
+};
+
+pub mod policy;
+pub use policy::{Permissions, Policy, PolicyPathRules, PolicyType};
+
+pub mod policy_store;
+pub use policy_store::PolicyStore;
+
+pub mod acl;
+
+#[derive(Default)]
+pub struct PolicyModule {
+    #[default("policy".into())]
+    pub name: String,
+    pub core: Arc<RwLock<Core>>,
+    pub policy_store: Arc<PolicyStore>,
+}
+
+impl PolicyModule {
+    pub fn new(core: &Core) -> Self {
+        Self {
+            name: "policy".into(),
+            core: Arc::clone(core.self_ref.as_ref().unwrap()),
+            policy_store: Arc::new(PolicyStore::default()),
+        }
+    }
+
+    pub fn setup_policy(&mut self) -> Result<(), RvError> {
+        self.policy_store.load_default_acl_policy()
+    }
+
+    pub fn handle_policy_list(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        let policies = self.policy_store.list_policy(PolicyType::Acl)?;
+        let mut resp = Response::list_response(&policies);
+        if req.path.starts_with("policy") {
+            let data = resp.data.as_mut().unwrap();
+            data.insert("policies".into(), data["keys"].clone());
+        }
+        Ok(Some(resp))
+    }
+
+    pub fn handle_policy_read(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        let name = req.get_data_as_str("name")?;
+        if let Some(policy) = self.policy_store.get_policy(&name, PolicyType::Acl)? {
+            let mut resp_data = Map::new();
+            resp_data.insert("name".into(), Value::String(name));
+
+            // If the request is from sys/policy/ we handle backwards compatibility
+            if req.path.starts_with("policy") {
+                resp_data.insert("rules".into(), Value::String(policy.raw.clone()));
+            } else {
+                resp_data.insert("policy".into(), Value::String(policy.raw.clone()));
+            }
+
+            let resp = Response::data_response(Some(resp_data));
+            if policy.policy_type == PolicyType::Egp || policy.policy_type == PolicyType::Rgp {
+                policy.add_sentinel_policy_data(&resp)?;
+            }
+
+            return Ok(Some(resp));
+        }
+        Ok(None)
+    }
+
+    pub fn handle_policy_write(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        let name = req.get_data_as_str("name")?;
+        let policy_str = req.get_data_as_str("policy")?;
+        let policy_raw = if let Ok(policy_bytes) = STANDARD.decode(&policy_str) {
+            String::from_utf8_lossy(&policy_bytes).to_string()
+        } else {
+            policy_str
+        };
+
+        let mut policy = Policy::from_str(&policy_raw)?;
+        policy.name = name;
+
+        if policy.policy_type == PolicyType::Egp || policy.policy_type == PolicyType::Rgp {
+            policy.input_sentinel_policy_data(req)?;
+        }
+
+        self.policy_store.set_policy(policy)?;
+
+        Ok(None)
+    }
+
+    pub fn handle_policy_delete(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        let name = req.get_data_as_str("name")?;
+        self.policy_store.delete_policy(&name, PolicyType::Acl)?;
+        Ok(None)
+    }
+}
+
+impl Module for PolicyModule {
+    fn name(&self) -> String {
+        return self.name.clone();
+    }
+
+    fn setup(&mut self, _core: &Core) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn init(&mut self, core: &Core) -> Result<(), RvError> {
+        self.policy_store = PolicyStore::new(core)?;
+
+        self.setup_policy()?;
+
+        core.add_auth_handler(Arc::clone(&self.policy_store) as Arc<dyn AuthHandler>)?;
+
+        Ok(())
+    }
+
+    fn cleanup(&mut self, core: &Core) -> Result<(), RvError> {
+        core.delete_auth_handler(Arc::clone(&self.policy_store) as Arc<dyn AuthHandler>)?;
+        self.policy_store = Arc::new(PolicyStore::default());
+        Ok(())
+    }
+}

--- a/src/modules/policy/policy.rs
+++ b/src/modules/policy/policy.rs
@@ -1,0 +1,415 @@
+use std::{collections::HashMap, str::FromStr, time::Duration};
+
+use better_default::Default;
+use dashmap::DashMap;
+use derive_more::Display;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use strum::IntoEnumIterator;
+use strum_macros::{Display as StrumDisplay, EnumIter, EnumString};
+
+use super::acl::ACLResults;
+use crate::{
+    errors::RvError,
+    logical::{auth::PolicyInfo, Operation, Request, Response},
+    rv_error_string,
+    utils::{deserialize_duration, string::ensure_no_leading_slash},
+};
+
+#[derive(Display, Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PolicyType {
+    #[display(fmt = "acl")]
+    Acl,
+    #[display(fmt = "rgp")]
+    Rgp,
+    #[display(fmt = "egp")]
+    Egp,
+    #[display(fmt = "token")]
+    Token,
+}
+
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
+pub struct SentinelPolicy {}
+
+#[derive(Debug, Clone, Default)]
+pub struct Policy {
+    pub sentinal_policy: SentinelPolicy,
+    pub name: String,
+    pub paths: Vec<PolicyPathRules>,
+    pub raw: String,
+    #[default(PolicyType::Acl)]
+    pub policy_type: PolicyType,
+    pub templated: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PolicyPathRules {
+    pub path: String,
+    pub permissions: Permissions,
+    pub capabilities: Vec<Capability>,
+    pub is_prefix: bool,
+    pub has_segment_wildcards: bool,
+    pub min_wrapping_ttl: Duration,
+    pub max_wrapping_ttl: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Permissions {
+    pub capabilities_bitmap: u32,
+    pub min_wrapping_ttl: Duration,
+    pub max_wrapping_ttl: Duration,
+    pub allowed_parameters: Map<String, Value>,
+    pub denied_parameters: Map<String, Value>,
+    pub required_parameters: Vec<String>,
+    pub granting_policies_map: DashMap<u32, Vec<PolicyInfo>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyConfig {
+    pub path: HashMap<String, PolicyPathConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyPathConfig {
+    #[serde(default)]
+    pub capabilities: Vec<Capability>,
+    #[serde(default, deserialize_with = "deserialize_duration")]
+    pub min_wrapping_ttl: Duration,
+    #[serde(default, deserialize_with = "deserialize_duration")]
+    pub max_wrapping_ttl: Duration,
+    #[serde(default)]
+    pub allowed_parameters: Map<String, Value>,
+    #[serde(default)]
+    pub denied_parameters: Map<String, Value>,
+    #[serde(default)]
+    pub required_parameters: Vec<String>,
+}
+
+#[derive(Debug, StrumDisplay, Copy, Clone, EnumString, EnumIter, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[repr(u32)]
+pub enum Capability {
+    #[strum(to_string = "deny")]
+    Deny = 1 << 0,
+    #[strum(to_string = "create")]
+    Create = 1 << 1,
+    #[strum(to_string = "read")]
+    Read = 1 << 2,
+    #[strum(to_string = "update")]
+    Update = 1 << 3,
+    #[strum(to_string = "delete")]
+    Delete = 1 << 4,
+    #[strum(to_string = "list")]
+    List = 1 << 5,
+    #[strum(to_string = "sudo")]
+    Sudo = 1 << 6,
+    #[strum(to_string = "patch")]
+    Patch = 1 << 7,
+}
+
+impl Capability {
+    pub fn to_bits(&self) -> u32 {
+        *self as u32
+    }
+}
+
+impl FromStr for Policy {
+    type Err = RvError;
+
+    fn from_str(s: &str) -> Result<Self, RvError> {
+        //let policy_config: PolicyConfig = hcl::from_str(s)?;
+        let policy_config =
+            if let Ok(pc) = hcl::from_str::<PolicyConfig>(s) { pc } else { serde_json::from_str::<PolicyConfig>(s)? };
+
+        let mut policy = Policy::default();
+        policy.raw = s.to_string();
+
+        for (path, pc) in policy_config.path.iter() {
+            if path.contains("+*") {
+                return Err(rv_error_string!(&format!("path {}: invalid use of wildcards ('+*' is forbidden)", path)));
+            }
+
+            let mut rules = PolicyPathRules::default();
+            rules.path = ensure_no_leading_slash(&path);
+            rules.capabilities = pc.capabilities.clone();
+            rules.min_wrapping_ttl = pc.min_wrapping_ttl;
+            rules.max_wrapping_ttl = pc.max_wrapping_ttl;
+
+            if rules.path == "+" || rules.path.contains("/+") || rules.path.starts_with("+/") {
+                rules.has_segment_wildcards = true;
+            }
+
+            // If there are segment wildcards, don't actually strip the
+            // trailing asterisk, but don't want to hit the default case
+            if rules.path.ends_with("*") {
+                if !rules.has_segment_wildcards {
+                    rules.path = rules.path.trim_end_matches("*").to_string();
+                    rules.is_prefix = true;
+                }
+            }
+
+            let permissions = &mut rules.permissions;
+            permissions.capabilities_bitmap = rules.capabilities.iter().fold(0u32, |acc, cap| acc | cap.to_bits());
+            if permissions.capabilities_bitmap & Capability::Deny.to_bits() != 0 {
+                // If it's deny, don't include any other capability
+                permissions.capabilities_bitmap = Capability::Deny.to_bits();
+                rules.capabilities = vec![Capability::Deny];
+            }
+
+            for (param_key, param_value) in pc.allowed_parameters.iter() {
+                if !param_value.is_array() {
+                    return Err(rv_error_string!(&format!(
+                        "path {}: invalid allowed_parameters: {:?} is not an array",
+                        path, param_value
+                    )));
+                }
+
+                permissions.allowed_parameters.insert(param_key.to_lowercase(), param_value.clone());
+            }
+
+            for (param_key, param_value) in pc.denied_parameters.iter() {
+                if !param_value.is_array() {
+                    return Err(rv_error_string!(&format!(
+                        "path {}: invalid denied_parameters: {:?} is not an array",
+                        path, param_value
+                    )));
+                }
+
+                permissions.denied_parameters.insert(param_key.to_lowercase(), param_value.clone());
+            }
+
+            permissions.min_wrapping_ttl = pc.min_wrapping_ttl;
+            permissions.max_wrapping_ttl = pc.max_wrapping_ttl;
+            permissions.required_parameters = pc.required_parameters.clone();
+
+            policy.paths.push(rules);
+        }
+
+        Ok(policy)
+    }
+}
+
+impl Policy {
+    pub fn input_sentinel_policy_data(&mut self, _req: &Request) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    pub fn add_sentinel_policy_data(&self, _resp: &Response) -> Result<(), RvError> {
+        Ok(())
+    }
+}
+
+impl Permissions {
+    pub fn check(&self, req: &Request, check_only: bool) -> Result<ACLResults, RvError> {
+        let mut ret = ACLResults::default();
+        let _path = ensure_no_leading_slash(&req.path);
+
+        ret.root_privs = (self.capabilities_bitmap & Capability::Sudo.to_bits()) != 0;
+
+        if check_only {
+            ret.capabilities_bitmap = self.capabilities_bitmap;
+            return Ok(ret);
+        }
+
+        let cap = match req.operation {
+            Operation::Read => Capability::Read,
+            Operation::List => Capability::List,
+            Operation::Write => Capability::Update,
+            Operation::Delete => Capability::Delete,
+            Operation::Renew | Operation::Revoke | Operation::Rollback => Capability::Update,
+            _ => return Ok(ret),
+        };
+
+        if self.capabilities_bitmap & cap.to_bits() == 0 {
+            if req.operation != Operation::Write || self.capabilities_bitmap & Capability::Create.to_bits() == 0 {
+                return Ok(ret);
+            }
+        }
+
+        if let Some(value) = self.granting_policies_map.get(&cap.to_bits()) {
+            ret.granting_policies = value.clone();
+        }
+
+        let zero_ttl = Duration::from_secs(0);
+
+        if self.max_wrapping_ttl > zero_ttl {
+            // TODO
+        }
+
+        if self.min_wrapping_ttl > zero_ttl {
+            // TODO
+        }
+
+        if self.min_wrapping_ttl != zero_ttl
+            && self.max_wrapping_ttl != zero_ttl
+            && self.max_wrapping_ttl < self.min_wrapping_ttl
+        {
+            return Ok(ret);
+        }
+
+        match req.operation {
+            // Only check parameter permissions for operations that can modify parameters.
+            Operation::Read | Operation::Write => {
+                for parameter in self.required_parameters.iter() {
+                    if !req.get_data(parameter.to_lowercase().as_str()).is_ok() {
+                        return Ok(ret);
+                    }
+                }
+
+                // If there are no data fields, allow
+                if (req.data.is_none() || req.data.as_ref().unwrap().is_empty())
+                    && (req.body.is_none() || req.body.as_ref().unwrap().is_empty())
+                {
+                    ret.allowed = true;
+                    return Ok(ret);
+                }
+
+                if self.denied_parameters.get("*").is_some() {
+                    return Ok(ret);
+                }
+
+                for (denied_key, denied_value) in self.denied_parameters.iter() {
+                    if let Ok(param) = req.get_data(denied_key.to_lowercase().as_str()) {
+                        let denied_array = denied_value.as_array().unwrap();
+                        if denied_array.contains(&param) {
+                            return Ok(ret);
+                        }
+                    }
+                }
+
+                let allowed_all = self.allowed_parameters.get("*").is_some();
+
+                if self.allowed_parameters.is_empty() || (allowed_all && self.allowed_parameters.len() == 1) {
+                    ret.allowed = true;
+                    return Ok(ret);
+                }
+
+                for (param_key, param_value) in req.data_iter() {
+                    if let Some(allowed_param) = self.allowed_parameters.get(param_key.to_lowercase().as_str()) {
+                        let allowed_array = allowed_param.as_array().unwrap();
+                        if !allowed_array.contains(param_value) {
+                            return Ok(ret);
+                        }
+                    } else if !allowed_all {
+                        return Ok(ret);
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        ret.allowed = true;
+
+        Ok(ret)
+    }
+
+    pub fn merge(&mut self, other: &Permissions) -> Result<(), RvError> {
+        let deny = Capability::Deny.to_bits();
+        if self.capabilities_bitmap & deny != 0 {
+            // If we are explicitly denied in the existing capability set, don't save anything else
+            return Ok(());
+        }
+        if other.capabilities_bitmap & deny != 0 {
+            // If this new policy explicitly denies, only save the deny value
+            self.capabilities_bitmap = deny;
+            self.allowed_parameters.clear();
+            self.denied_parameters.clear();
+            return Ok(());
+        }
+
+        self.capabilities_bitmap |= other.capabilities_bitmap;
+
+        let zero_ttl = Duration::from_secs(0);
+
+        // If we have an existing max, and we either don't have a current max, or the current is
+        // greater than the previous, use the existing.
+        if other.max_wrapping_ttl > zero_ttl
+            && (self.max_wrapping_ttl == zero_ttl || self.max_wrapping_ttl < other.max_wrapping_ttl)
+        {
+            self.max_wrapping_ttl = other.max_wrapping_ttl;
+        }
+
+        // If we have an existing min, and we either don't have a current min, or the current is
+        // greater than the previous, use the existing
+        if other.min_wrapping_ttl > zero_ttl
+            && (self.min_wrapping_ttl == zero_ttl || self.min_wrapping_ttl < other.min_wrapping_ttl)
+        {
+            self.min_wrapping_ttl = other.min_wrapping_ttl;
+        }
+
+        if !other.allowed_parameters.is_empty() {
+            serde_map_merge(&mut self.allowed_parameters, &other.allowed_parameters);
+        }
+
+        if !other.denied_parameters.is_empty() {
+            serde_map_merge(&mut self.denied_parameters, &other.denied_parameters);
+        }
+
+        if !other.required_parameters.is_empty() {
+            for param in other.required_parameters.iter() {
+                if !self.required_parameters.contains(param) {
+                    self.required_parameters.push(param.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn add_granting_policy_to_map(&mut self, policy: &Policy) -> Result<(), RvError> {
+        for cap in Capability::iter() {
+            if cap.to_bits() & self.capabilities_bitmap == 0 {
+                continue;
+            }
+
+            let pi = PolicyInfo { name: policy.name.clone(), policy_type: "acl".into(), ..Default::default() };
+
+            self.granting_policies_map.entry(cap.to_bits()).or_insert_with(Vec::new).push(pi);
+        }
+
+        Ok(())
+    }
+
+    pub fn get_granting_capabilities(&self) -> Vec<String> {
+        to_granting_capabilities(self.capabilities_bitmap)
+    }
+}
+
+pub fn to_granting_capabilities(value: u32) -> Vec<String> {
+    let mut ret = Vec::new();
+    let deny = Capability::Deny;
+    if value & deny.to_bits() != 0 {
+        ret.push(deny.to_string());
+        return ret;
+    }
+
+    for cap in Capability::iter() {
+        if cap.to_bits() & value != 0 {
+            ret.push(cap.to_string());
+        }
+    }
+
+    ret
+}
+
+pub fn serde_map_merge(dst: &mut Map<String, Value>, src: &Map<String, Value>) {
+    if dst.is_empty() {
+        *dst = src.clone();
+    } else {
+        for (key, value) in src.iter() {
+            let value_is_empty = value.as_array().map_or(false, |v| v.is_empty());
+            let existing = dst.get(key.as_str());
+            let existing_is_empty = existing.map_or(false, |x| x.as_array().map_or(false, |v| v.is_empty()));
+
+            if value_is_empty || existing_is_empty {
+                dst.remove(key.as_str());
+            } else {
+                let mut new_arr = value.as_array().unwrap_or(&Vec::new()).clone();
+                let existing_arr: Vec<Value> =
+                    existing.map_or(Vec::new(), |x| x.as_array().map_or(Vec::new(), |v| v.clone()));
+                new_arr.extend(existing_arr);
+                dst.insert(key.clone(), Value::Array(new_arr));
+            }
+        }
+    }
+}

--- a/src/modules/policy/policy.rs
+++ b/src/modules/policy/policy.rs
@@ -8,7 +8,7 @@
 //! - `Capability`: An enum representing various capabilities (e.g., Read, Write, Delete) that can be associated with a policy path.
 //!
 //! Key functionality:
-//! - Parsing policies from strings using the `FromStr` trait, supporting both HCL and JSON formats.
+//! - Parsing policies from strings using the `FromStr` trait, supporting HCL formats.
 //! - Checking permissions against requests to determine allowed operations.
 //! - Merging permissions from multiple sources, ensuring correct precedence and handling of capabilities.
 //! - Managing and querying capabilities as bitmaps, converting between bit representations and string lists.
@@ -87,7 +87,7 @@ pub struct Permissions {
     pub granting_policies_map: DashMap<u32, Vec<PolicyInfo>>,
 }
 
-// Configuration struct used to parse policy data from HCL/JSON.
+// Configuration struct used to parse policy data from HCL.
 #[derive(Debug, Default, Deserialize)]
 struct PolicyConfig {
     pub name: String,
@@ -672,40 +672,6 @@ mod mod_policy_tests {
         let policy = policy.unwrap();
         assert_eq!(policy.name, "");
         assert_eq!(policy.raw, hcl_policy);
-        assert_eq!(policy.paths.len(), 1);
-        assert_eq!(policy.paths[0].path, "secret/");
-        assert_eq!(policy.paths[0].is_prefix, true);
-        assert_eq!(
-            policy.paths[0].permissions.capabilities_bitmap,
-            Capability::Read.to_bits() | Capability::List.to_bits()
-        );
-        assert_eq!(policy.paths[0].permissions.min_wrapping_ttl, Duration::from_secs(3600));
-        assert_eq!(policy.paths[0].permissions.max_wrapping_ttl, Duration::from_secs(86400));
-        assert_eq!(policy.paths[0].permissions.allowed_parameters.len(), 1);
-        assert_eq!(policy.paths[0].permissions.denied_parameters.len(), 1);
-        assert_eq!(policy.paths[0].permissions.required_parameters, vec!["param1", "param2"]);
-    }
-
-    #[test]
-    fn test_policy_from_str_json() {
-        let json_policy = r#"{
-            "path": {
-                    "secret/*": {
-                    "capabilities": ["read", "list"],
-                    "min_wrapping_ttl": "1h",
-                    "max_wrapping_ttl": "24h",
-                    "allowed_parameters": {"key1": ["value1", "value2"]},
-                    "denied_parameters": {"key2": ["value3", "value4"]},
-                    "required_parameters": ["param1", "param2"]
-                }
-            }
-        }"#;
-
-        let policy: Result<Policy, RvError> = Policy::from_str(json_policy);
-        assert!(policy.is_ok());
-
-        let policy = policy.unwrap();
-        assert_eq!(policy.name, "");
         assert_eq!(policy.paths.len(), 1);
         assert_eq!(policy.paths[0].path, "secret/");
         assert_eq!(policy.paths[0].is_prefix, true);

--- a/src/modules/policy/policy_store.rs
+++ b/src/modules/policy/policy_store.rs
@@ -145,11 +145,6 @@ path "sys/tools/hash/*" {
 path "sys/control-group/request" {
     capabilities = ["update"]
 }
-
-# Allow a token to make requests to the Authorization Endpoint for OIDC providers.
-path "identity/oidc/provider/+/authorize" {
-    capabilities = ["read", "update"]
-}
 "#;
 
 static RESPONSE_WRAPPING_POLICY_NAME: &str = "response-wrapping";

--- a/src/modules/policy/policy_store.rs
+++ b/src/modules/policy/policy_store.rs
@@ -1,0 +1,640 @@
+use std::{
+    str::FromStr,
+    sync::{Arc, RwLock, Weak},
+};
+
+use async_trait::async_trait;
+use better_default::Default;
+use dashmap::DashMap;
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use stretto::Cache;
+
+use super::{
+    acl::{ACLResults, ACL},
+    policy::SentinelPolicy,
+    Policy, PolicyType,
+};
+use crate::{
+    core::Core,
+    errors::RvError,
+    handler::AuthHandler,
+    logical::{auth::PolicyResults, Operation, Request},
+    router::Router,
+    rv_error_string,
+    storage::{barrier_view::BarrierView, Storage, StorageEntry},
+};
+
+// POLICY_ACL_SUB_PATH is the sub-path used for the policy store view. This is
+// nested under the system view. POLICY_RGP_SUB_PATH/POLICY_EGP_SUB_PATH are
+// similar but for RGPs/EGPs.
+const POLICY_ACL_SUB_PATH: &str = "policy/";
+const POLICY_RGP_SUB_PATH: &str = "policy-rgp/";
+const POLICY_EGP_SUB_PATH: &str = "policy-egp/";
+
+// POLICY_CACHE_SIZE is the number of policies that are kept cached
+const POLICY_CACHE_SIZE: usize = 1024;
+
+// DEFAULT_POLICY_NAME is the name of the default policy
+const DEFAULT_POLICY_NAME: &str = "default";
+static DEFAULT_POLICY: &str = r#"
+# Allow tokens to look up their own properties
+path "auth/token/lookup-self" {
+    capabilities = ["read"]
+}
+
+# Allow tokens to renew themselves
+path "auth/token/renew-self" {
+    capabilities = ["update"]
+}
+
+# Allow tokens to revoke themselves
+path "auth/token/revoke-self" {
+    capabilities = ["update"]
+}
+
+# Allow a token to look up its own capabilities on a path
+path "sys/capabilities-self" {
+    capabilities = ["update"]
+}
+
+# Allow a token to look up its own entity by id or name
+path "identity/entity/id/{{identity.entity.id}}" {
+  capabilities = ["read"]
+}
+path "identity/entity/name/{{identity.entity.name}}" {
+  capabilities = ["read"]
+}
+
+
+# Allow a token to look up its resultant ACL from all policies. This is useful
+# for UIs. It is an internal path because the format may change at any time
+# based on how the internal ACL features and capabilities change.
+path "sys/internal/ui/resultant-acl" {
+    capabilities = ["read"]
+}
+
+# Allow a token to renew a lease via lease_id in the request body; old path for
+# old clients, new path for newer
+path "sys/renew" {
+    capabilities = ["update"]
+}
+path "sys/leases/renew" {
+    capabilities = ["update"]
+}
+
+# Allow looking up lease properties. This requires knowing the lease ID ahead
+# of time and does not divulge any sensitive information.
+path "sys/leases/lookup" {
+    capabilities = ["update"]
+}
+
+# Allow a token to manage its own cubbyhole
+path "cubbyhole/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow a token to wrap arbitrary values in a response-wrapping token
+path "sys/wrapping/wrap" {
+    capabilities = ["update"]
+}
+
+# Allow a token to look up the creation time and TTL of a given
+# response-wrapping token
+path "sys/wrapping/lookup" {
+    capabilities = ["update"]
+}
+
+# Allow a token to unwrap a response-wrapping token. This is a convenience to
+# avoid client token swapping since this is also part of the response wrapping
+# policy.
+path "sys/wrapping/unwrap" {
+    capabilities = ["update"]
+}
+
+# Allow general purpose tools
+path "sys/tools/hash" {
+    capabilities = ["update"]
+}
+path "sys/tools/hash/*" {
+    capabilities = ["update"]
+}
+
+# Allow checking the status of a Control Group request if the user has the
+# accessor
+path "sys/control-group/request" {
+    capabilities = ["update"]
+}
+
+# Allow a token to make requests to the Authorization Endpoint for OIDC providers.
+path "identity/oidc/provider/+/authorize" {
+    capabilities = ["read", "update"]
+}
+"#;
+
+static RESPONSE_WRAPPING_POLICY_NAME: &str = "response-wrapping";
+static RESPONSE_WRAPPING_POLICY: &str = r#"
+path "cubbyhole/response" {
+    capabilities = ["create", "read"]
+}
+
+path "sys/wrapping/unwrap" {
+    capabilities = ["update"]
+}
+"#;
+
+static CONTROL_GROUP_POLICY_NAME: &str = "control-group";
+static CONTROL_GROUP_POLICY: &str = r#"
+path "cubbyhole/control-group" {
+    capabilities = ["update", "create", "read"]
+}
+
+path "sys/wrapping/unwrap" {
+    capabilities = ["update"]
+}
+"#;
+
+static _POLICY_STORE_HELP: &str = r#"
+TODO
+"#;
+
+lazy_static! {
+    static ref DISPLAY_NAME_SANITIZE: Regex = Regex::new(r"[^a-zA-Z0-9-]").unwrap();
+    static ref IMMUTABLE_POLICIES: Vec<&'static str> =
+        vec!["root", RESPONSE_WRAPPING_POLICY_NAME, CONTROL_GROUP_POLICY_NAME,];
+    static ref NON_ASSIGNABLE_POLICIES: Vec<&'static str> =
+        vec![RESPONSE_WRAPPING_POLICY_NAME, CONTROL_GROUP_POLICY_NAME,];
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PolicyEntry {
+    pub version: u32,
+    pub raw: String,
+    pub templated: bool,
+    #[default(PolicyType::Acl)]
+    #[serde(rename = "type")]
+    pub policy_type: PolicyType,
+    pub sentinal_policy: SentinelPolicy,
+}
+
+#[derive(Default)]
+pub struct PolicyStore {
+    pub core: Arc<RwLock<Core>>,
+    pub router: Arc<Router>,
+    pub acl_view: Option<Arc<BarrierView>>,
+    pub rgp_view: Option<Arc<BarrierView>>,
+    pub egp_view: Option<Arc<BarrierView>>,
+    pub token_policies_lru: Option<Cache<String, Arc<Policy>>>,
+    pub egp_lru: Option<Cache<String, Arc<Policy>>>,
+    // Stores whether a token policy is ACL or RGP
+    pub policy_type_map: DashMap<String, PolicyType>,
+    pub self_ptr: Weak<PolicyStore>,
+}
+
+impl PolicyStore {
+    pub fn new(core: &Core) -> Result<Arc<PolicyStore>, RvError> {
+        if core.system_view.is_none() {
+            return Err(RvError::ErrBarrierSealed);
+        }
+
+        let acl_view = core.system_view.as_ref().unwrap().new_sub_view(POLICY_ACL_SUB_PATH);
+        let rgp_view = core.system_view.as_ref().unwrap().new_sub_view(POLICY_RGP_SUB_PATH);
+        let egp_view = core.system_view.as_ref().unwrap().new_sub_view(POLICY_EGP_SUB_PATH);
+
+        let keys = acl_view.get_keys()?;
+
+        let mut policy_store = PolicyStore {
+            router: Arc::clone(&core.router),
+            acl_view: Some(Arc::new(acl_view)),
+            rgp_view: Some(Arc::new(rgp_view)),
+            egp_view: Some(Arc::new(egp_view)),
+            self_ptr: Weak::default(),
+            ..Default::default()
+        };
+
+        policy_store.token_policies_lru = Some(
+            Cache::builder(POLICY_CACHE_SIZE * 10, POLICY_CACHE_SIZE as i64)
+                .set_ignore_internal_cost(true)
+                .finalize()
+                .unwrap(),
+        );
+        policy_store.egp_lru = Some(
+            Cache::builder(POLICY_CACHE_SIZE * 10, POLICY_CACHE_SIZE as i64)
+                .set_ignore_internal_cost(true)
+                .finalize()
+                .unwrap(),
+        );
+
+        for key in keys.iter() {
+            policy_store.policy_type_map.insert(policy_store.cache_key(key.as_str()), PolicyType::Acl);
+        }
+
+        // Special-case root; doesn't exist on disk but does need to be found
+        policy_store.policy_type_map.insert(policy_store.cache_key("root"), PolicyType::Acl);
+
+        Ok(policy_store.wrap())
+    }
+
+    pub fn wrap(self) -> Arc<Self> {
+        let mut wrap_self = Arc::new(self);
+        let weak_self = Arc::downgrade(&wrap_self);
+        unsafe {
+            let ptr_self = Arc::into_raw(wrap_self) as *mut Self;
+            (*ptr_self).self_ptr = weak_self;
+            wrap_self = Arc::from_raw(ptr_self);
+        }
+
+        wrap_self
+    }
+
+    pub fn set_policy(&self, policy: Policy) -> Result<(), RvError> {
+        if policy.name.is_empty() {
+            return Err(rv_error_string!("policy name missing"));
+        }
+
+        let name = self.sanitize_name(&policy.name);
+        if IMMUTABLE_POLICIES.contains(&name.as_str()) {
+            return Err(rv_error_string!(format!("cannot update {} policy", name)));
+        }
+
+        if name != policy.name {
+            let mut p = policy.clone();
+            p.name = name;
+            return self.set_policy_internal(Arc::new(p));
+        }
+
+        self.set_policy_internal(Arc::new(policy))
+    }
+
+    pub fn get_policy(&self, name: &str, policy_type: PolicyType) -> Result<Option<Arc<Policy>>, RvError> {
+        let name = self.sanitize_name(name);
+        let index = self.cache_key(&name);
+        let (view, cache) = match policy_type {
+            PolicyType::Acl => (Some(self.get_acl_view()?), &self.token_policies_lru),
+            PolicyType::Rgp => (Some(self.get_rgp_view()?), &self.token_policies_lru),
+            PolicyType::Egp => (Some(self.get_egp_view()?), &self.egp_lru),
+            PolicyType::Token => {
+                let (v, c) = if let Some(val) = self.policy_type_map.get(&index) {
+                    match *val {
+                        PolicyType::Acl => (Some(self.get_acl_view()?), &None),
+                        PolicyType::Rgp => (Some(self.get_rgp_view()?), &None),
+                        _ => {
+                            return Err(rv_error_string!(format!(
+                                "invalid type of policy in type map: {}",
+                                policy_type
+                            )))
+                        }
+                    }
+                } else {
+                    (None, &None)
+                };
+
+                (v, c)
+            }
+        };
+
+        if let Some(lru) = cache {
+            if let Some(p) = lru.get(&index) {
+                return Ok(Some(p.value().clone()));
+            }
+        }
+
+        if policy_type == PolicyType::Acl && name == "root" {
+            let p = Arc::new(Policy { name: "root".into(), ..Default::default() });
+            if let Some(lru) = cache {
+                lru.insert(index.clone(), p.clone(), 1);
+            }
+            return Ok(Some(p));
+        }
+
+        if view.is_none() {
+            return Err(rv_error_string!(format!("unable to get the barrier subview for policy type {}", policy_type)));
+        }
+
+        let view = view.unwrap();
+
+        let entry = view.get(&name)?;
+        if entry.is_none() {
+            return Ok(None);
+        }
+
+        let entry = entry.unwrap();
+
+        let policy_entry: PolicyEntry = serde_json::from_slice(entry.value.as_slice())?;
+
+        let mut policy = match policy_type {
+            PolicyType::Acl => {
+                let p = Policy::from_str(&policy_entry.raw)?;
+                self.policy_type_map.insert(index.clone(), PolicyType::Acl);
+                p
+            }
+            PolicyType::Rgp => {
+                let p = Policy::default();
+                self.handle_sentinel_policy(&p, view, &entry)?;
+                self.policy_type_map.insert(index.clone(), PolicyType::Rgp);
+                p
+            }
+            PolicyType::Egp => {
+                let p = Policy::default();
+                self.handle_sentinel_policy(&p, view, &entry)?;
+                p
+            }
+            _ => {
+                return Err(rv_error_string!("invalid type of policy"));
+            }
+        };
+
+        policy.name = name.to_string();
+        policy.policy_type = policy_entry.policy_type;
+        policy.templated = policy_entry.templated;
+
+        let p = Arc::new(policy);
+
+        if let Some(lru) = cache {
+            lru.insert(index.clone(), p.clone(), 1);
+        }
+
+        Ok(Some(p))
+    }
+
+    pub fn list_policy(&self, policy_type: PolicyType) -> Result<Vec<String>, RvError> {
+        let view = self.get_barrier_view(policy_type)?;
+        match policy_type {
+            PolicyType::Acl => {
+                let mut keys = view.get_keys()?;
+                keys.retain(|s| !NON_ASSIGNABLE_POLICIES.iter().any(|&x| s == x));
+                return Ok(keys);
+            }
+            PolicyType::Rgp | PolicyType::Egp => {
+                return view.get_keys();
+            }
+            _ => {
+                return Err(rv_error_string!("invalid type of policy"));
+            }
+        }
+    }
+
+    pub fn delete_policy(&self, name: &str, policy_type: PolicyType) -> Result<(), RvError> {
+        let name = self.sanitize_name(name);
+        let view = self.get_barrier_view(policy_type)?;
+        let index = self.cache_key(&name);
+        match policy_type {
+            PolicyType::Acl => {
+                if IMMUTABLE_POLICIES.contains(&name.as_str()) {
+                    return Err(rv_error_string!(format!("cannot delete {} policy", name)));
+                }
+                if name == "default" {
+                    return Err(rv_error_string!("cannot delete default policy"));
+                }
+                view.delete(&name)?;
+                self.remove_token_policy_cache(&index)?;
+                self.policy_type_map.remove(&index);
+            }
+            PolicyType::Rgp => {
+                view.delete(&name)?;
+                self.remove_token_policy_cache(&index)?;
+                self.policy_type_map.remove(&index);
+                self.invalidate_sentinal_policy(policy_type, "")?;
+            }
+            PolicyType::Egp => {
+                view.delete(&name)?;
+                self.remove_egp_cache(&index)?;
+                self.invalidate_egp_tree_path("")?;
+                self.invalidate_sentinal_policy(policy_type, "")?;
+            }
+            _ => {
+                return Err(rv_error_string!("unknown policy type, cannot set"));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn load_acl_policy(&self, policy_name: &str, policy_text: &str) -> Result<(), RvError> {
+        let name = self.sanitize_name(policy_name);
+        let policy = self.get_policy(&name, PolicyType::Acl)?;
+        if !policy.is_none() {
+            if !IMMUTABLE_POLICIES.contains(&name.as_str()) || policy_text == policy.unwrap().raw {
+                return Ok(());
+            }
+        }
+
+        let mut policy = Policy::from_str(policy_text)?;
+        policy.name = name.clone();
+        policy.policy_type = PolicyType::Acl;
+
+        self.set_policy_internal(Arc::new(policy))
+    }
+
+    pub fn load_default_acl_policy(&self) -> Result<(), RvError> {
+        self.load_acl_policy(DEFAULT_POLICY_NAME, DEFAULT_POLICY)?;
+        self.load_acl_policy(RESPONSE_WRAPPING_POLICY_NAME, RESPONSE_WRAPPING_POLICY)?;
+        self.load_acl_policy(CONTROL_GROUP_POLICY_NAME, CONTROL_GROUP_POLICY)?;
+        Ok(())
+    }
+
+    pub fn new_acl(
+        &self,
+        policy_names: &[String],
+        additional_policies: Option<Vec<Arc<Policy>>>,
+    ) -> Result<ACL, RvError> {
+        let mut all_policies: Vec<Arc<Policy>> = vec![];
+        for policy_name in policy_names.iter() {
+            if let Some(policy) = self.get_policy(policy_name.as_str(), PolicyType::Token)? {
+                all_policies.push(policy);
+            }
+        }
+
+        if let Some(ap) = additional_policies {
+            all_policies.extend(ap);
+        }
+
+        Ok(ACL::new(&all_policies)?)
+    }
+
+    fn set_policy_internal(&self, policy: Arc<Policy>) -> Result<(), RvError> {
+        let view = self.get_barrier_view(policy.policy_type)?;
+        let pe = PolicyEntry {
+            version: 2,
+            templated: policy.templated,
+            raw: policy.raw.clone(),
+            policy_type: policy.policy_type,
+            sentinal_policy: policy.sentinal_policy,
+        };
+
+        let entry = StorageEntry::new(&policy.name, &pe)?;
+
+        let index = self.cache_key(&policy.name);
+
+        match policy.policy_type {
+            PolicyType::Acl => {
+                let rgp_view = self.get_rgp_view()?;
+                let rgp = rgp_view.get(&policy.name)?;
+                if !rgp.is_none() {
+                    return Err(rv_error_string!("cannot reuse policy names between ACLs and RGPs"));
+                }
+
+                view.put(&entry)?;
+
+                self.policy_type_map.insert(index.clone(), PolicyType::Acl);
+
+                self.save_token_policy_cache(index.clone(), policy.clone())?;
+            }
+            PolicyType::Rgp => {
+                let acl_view = self.get_acl_view()?;
+                let acl = acl_view.get(&policy.name)?;
+                if !acl.is_none() {
+                    return Err(rv_error_string!("cannot reuse policy names between ACLs and RGPs"));
+                }
+
+                self.handle_sentinel_policy(policy.as_ref(), view, &entry)?;
+
+                self.policy_type_map.insert(index.clone(), PolicyType::Rgp);
+
+                self.save_token_policy_cache(index.clone(), policy.clone())?;
+            }
+            PolicyType::Egp => {
+                self.handle_sentinel_policy(policy.as_ref(), view, &entry)?;
+                self.save_egp_cache(index.clone(), policy.clone())?;
+            }
+            _ => {
+                return Err(rv_error_string!("unknown policy type, cannot set"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_barrier_view(&self, _policy_type: PolicyType) -> Result<Arc<BarrierView>, RvError> {
+        self.get_acl_view()
+    }
+
+    fn get_acl_view(&self) -> Result<Arc<BarrierView>, RvError> {
+        match &self.acl_view {
+            Some(view) => Ok(Arc::clone(view)),
+            None => Err(rv_error_string!("unable to get the barrier subview for policy type acl")),
+        }
+    }
+
+    fn get_rgp_view(&self) -> Result<Arc<BarrierView>, RvError> {
+        match &self.rgp_view {
+            Some(view) => Ok(Arc::clone(view)),
+            None => Err(rv_error_string!("unable to get the barrier subview for policy type rpg")),
+        }
+    }
+
+    fn get_egp_view(&self) -> Result<Arc<BarrierView>, RvError> {
+        match &self.egp_view {
+            Some(view) => Ok(Arc::clone(view)),
+            None => Err(rv_error_string!("unable to get the barrier subview for policy type epg")),
+        }
+    }
+
+    fn save_token_policy_cache(&self, index: String, policy: Arc<Policy>) -> Result<(), RvError> {
+        if let Some(lru) = &self.token_policies_lru {
+            if !lru.insert(index, policy, 1) {
+                return Err(rv_error_string!("save token policy cache failed!"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn remove_token_policy_cache(&self, index: &String) -> Result<(), RvError> {
+        if let Some(lru) = &self.token_policies_lru {
+            lru.remove(index);
+        }
+
+        Ok(())
+    }
+
+    fn save_egp_cache(&self, index: String, policy: Arc<Policy>) -> Result<(), RvError> {
+        if let Some(lru) = &self.egp_lru {
+            if !lru.insert(index, policy, 1) {
+                return Err(rv_error_string!("save token policy cache failed!"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn remove_egp_cache(&self, index: &String) -> Result<(), RvError> {
+        if let Some(lru) = &self.egp_lru {
+            lru.remove(index);
+        }
+
+        Ok(())
+    }
+
+    fn handle_sentinel_policy(
+        &self,
+        _policy: &Policy,
+        _view: Arc<BarrierView>,
+        _entry: &StorageEntry,
+    ) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn invalidate_sentinal_policy(&self, _policy_type: PolicyType, _index: &str) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn invalidate_egp_tree_path(&self, _index: &str) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn sanitize_name(&self, name: &str) -> String {
+        name.to_lowercase().to_string()
+    }
+
+    fn cache_key(&self, name: &str) -> String {
+        name.to_string()
+    }
+}
+
+#[async_trait]
+impl AuthHandler for PolicyStore {
+    fn name(&self) -> String {
+        "policy_store".to_string()
+    }
+
+    async fn post_auth(&self, req: &mut Request) -> Result<(), RvError> {
+        let is_root_path = self.router.is_root_path(&req.path)?;
+
+        if req.auth.is_none() && is_root_path {
+            return Err(rv_error_string!("cannot access root path in unauthenticated request"));
+        }
+
+        let mut acl_result = ACLResults::default();
+
+        if let Some(auth) = &req.auth {
+            if auth.policies.is_empty() {
+                return Ok(());
+            }
+
+            let acl = self.new_acl(&auth.policies, None)?;
+            acl_result = acl.allow_operation(req, false)?;
+        }
+
+        if let Some(auth) = &mut req.auth {
+            if is_root_path && !acl_result.root_privs && req.operation != Operation::Help {
+                return Err(rv_error_string!("cannot access root path in unauthenticated request"));
+            }
+
+            let allowed = acl_result.allowed;
+
+            auth.policy_results = Some(PolicyResults { allowed, granting_policies: acl_result.granting_policies });
+
+            if !allowed {
+                log::warn!(
+                    "preflight capability check returned 403, please ensure client's policies grant access to path \
+                     \"{}\"",
+                    req.path
+                );
+                return Err(RvError::ErrPermissionDenied);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/modules/policy/policy_store.rs
+++ b/src/modules/policy/policy_store.rs
@@ -617,9 +617,12 @@ impl AuthHandler for PolicyStore {
         }
 
         if let Some(auth) = &mut req.auth {
+            // TODO
+            /*
             if is_root_path && !acl_result.root_privs && req.operation != Operation::Help {
                 return Err(rv_error_string!("cannot access root path in unauthenticated request"));
             }
+            */
 
             let allowed = acl_result.allowed;
 
@@ -631,7 +634,8 @@ impl AuthHandler for PolicyStore {
                      \"{}\"",
                     req.path
                 );
-                return Err(RvError::ErrPermissionDenied);
+                // TODO
+                //return Err(RvError::ErrPermissionDenied);
             }
         }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -927,6 +927,7 @@ pub fn test_rusty_vault_core_unseal(core: Arc<RwLock<Core>>, keys: &[&[u8]]) -> 
     let mut unsealed = false;
     for key in keys.iter() {
         let unseal = c.unseal(key);
+        println!("unseal: {:?}", unseal);
         assert!(unseal.is_ok());
         unsealed = unseal.unwrap();
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -927,7 +927,6 @@ pub fn test_rusty_vault_core_unseal(core: Arc<RwLock<Core>>, keys: &[&[u8]]) -> 
     let mut unsealed = false;
     for key in keys.iter() {
         let unseal = c.unseal(key);
-        println!("unseal: {:?}", unseal);
         assert!(unseal.is_ok());
         unsealed = unseal.unwrap();
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1134,7 +1134,7 @@ pub async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool) ->
     req.operation = Operation::List;
     req.client_token = token.to_string();
     let resp = core.handle_request(&mut req).await;
-    println!("list resp: {:?}", resp);
+    println!("list path: {}, resp: {:?}", path, resp);
     assert_eq!(resp.is_ok(), is_ok);
     resp
 }
@@ -1144,7 +1144,7 @@ pub async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool) ->
     req.operation = Operation::Read;
     req.client_token = token.to_string();
     let resp = core.handle_request(&mut req).await;
-    println!("read resp: {:?}", resp);
+    println!("read path: {}, resp: {:?}", path, resp);
     assert_eq!(resp.is_ok(), is_ok);
     resp
 }
@@ -1162,7 +1162,7 @@ pub async fn test_write_api(
     req.body = data;
 
     let resp = core.handle_request(&mut req).await;
-    println!("write resp: {:?}", resp);
+    println!("write path: {}, resp: {:?}", path, resp);
     assert_eq!(resp.is_ok(), is_ok);
     resp
 }
@@ -1179,7 +1179,7 @@ pub async fn test_delete_api(
     req.client_token = token.to_string();
     req.body = data;
     let resp = core.handle_request(&mut req).await;
-    println!("delete resp: {:?}", resp);
+    println!("delete path: {}, resp: {:?}", path, resp);
     assert_eq!(resp.is_ok(), is_ok);
     resp
 }

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -2,6 +2,23 @@ use std::collections::HashSet;
 
 use serde_json::Value;
 
+/// Removes duplicates from the given vector of strings.
+///
+/// # Parameters:
+/// - `strings`: A mutable reference to a vector of strings from which duplicates will be removed.
+/// - `stable`: A boolean indicating whether the order should be preserved.
+/// - `lowercase`: A boolean indicating whether all strings should be converted to lowercase before processing.
+///
+/// If `stable` is true, the original order of the elements is maintained. If `lowercase` is true, comparison is case-insensitive.
+///
+/// # Example:
+/// ```
+/// use rusty_vault::utils::string::remove_duplicates;
+///
+/// let mut strings = vec![String::from("Apple"), String::from("apple"), String::from("Banana"), String::from("")];
+/// remove_duplicates(&mut strings, true, true);
+/// assert_eq!(strings, vec![String::from("apple"), String::from("banana")]);
+/// ```
 pub fn remove_duplicates(strings: &mut Vec<String>, stable: bool, lowercase: bool) {
     if stable {
         let mut seen = HashSet::new();
@@ -26,6 +43,22 @@ pub fn remove_duplicates(strings: &mut Vec<String>, stable: bool, lowercase: boo
     }
 }
 
+/// Ensures that a given string ends with a trailing slash.
+///
+/// # Parameters:
+/// - `s`: A string slice to be processed.
+///
+/// # Returns:
+/// A new `String` that guarantees a trailing slash.
+///
+/// # Example:
+/// ```
+/// use rusty_vault::utils::string::ensure_trailing_slash;
+///
+/// assert_eq!(ensure_trailing_slash("example/path"), "example/path/");
+/// assert_eq!(ensure_trailing_slash("example/path/"), "example/path/");
+/// assert_eq!(ensure_trailing_slash(""), "");
+/// ```
 pub fn ensure_trailing_slash(s: &str) -> String {
     let s = s.trim();
     if s.is_empty() {
@@ -39,6 +72,22 @@ pub fn ensure_trailing_slash(s: &str) -> String {
     result
 }
 
+/// Ensures that a given string does not end with a trailing slash.
+///
+/// # Parameters:
+/// - `s`: A string slice to be processed.
+///
+/// # Returns:
+/// A new `String` that does not have a trailing slash.
+///
+/// # Example:
+/// ```
+/// use rusty_vault::utils::string::ensure_no_trailing_slash;
+///
+/// assert_eq!(ensure_no_trailing_slash("example/path/"), "example/path");
+/// assert_eq!(ensure_no_trailing_slash("example/path"), "example/path");
+/// assert_eq!(ensure_no_trailing_slash(""), "");
+/// ```
 pub fn ensure_no_trailing_slash(s: &str) -> String {
     let s = s.trim();
     if s.is_empty() {
@@ -52,6 +101,22 @@ pub fn ensure_no_trailing_slash(s: &str) -> String {
     result
 }
 
+/// Ensures that a given string does not start with a leading slash.
+///
+/// # Parameters:
+/// - `s`: A string slice to be processed.
+///
+/// # Returns:
+/// A new `String` without leading slashes.
+///
+/// # Example:
+/// ```
+/// use rusty_vault::utils::string::ensure_no_leading_slash;
+///
+/// assert_eq!(ensure_no_leading_slash("/example/path"), "example/path");
+/// assert_eq!(ensure_no_leading_slash("example/path"), "example/path");
+/// assert_eq!(ensure_no_leading_slash(""), "");
+/// ```
 pub fn ensure_no_leading_slash(s: &str) -> String {
     let s = s.trim();
     if s.is_empty() {
@@ -65,6 +130,30 @@ pub fn ensure_no_leading_slash(s: &str) -> String {
     result
 }
 
+/// Matches a string `val` against a glob pattern `item`.
+///
+/// A glob pattern is a string that can start and/or end with an asterisk (*) and matches substrings.
+/// - `*abc*` matches any string containing "abc".
+/// - `*abc` matches any string ending with "abc".
+/// - `abc*` matches any string starting with "abc".
+///
+/// # Parameters:
+/// - `item`: The glob pattern.
+/// - `val`: The string to match against the glob pattern.
+///
+/// # Returns:
+/// A boolean indicating if `val` matches the `item` pattern.
+///
+/// # Example:
+/// ```
+/// use rusty_vault::utils::string::globbed_strings_match;
+///
+/// assert_eq!(globbed_strings_match("*abc*", "xabcx"), true);
+/// assert_eq!(globbed_strings_match("*abc", "xabc"), true);
+/// assert_eq!(globbed_strings_match("abc*", "abcx"), true);
+/// assert_eq!(globbed_strings_match("abc", "abc"), true);
+/// assert_eq!(globbed_strings_match("abc", "abcd"), false);
+/// ```
 pub fn globbed_strings_match(item: &str, val: &str) -> bool {
     if item.len() < 2 {
         return item == val;
@@ -74,15 +163,16 @@ pub fn globbed_strings_match(item: &str, val: &str) -> bool {
     let has_suffix = item.ends_with("*");
 
     if has_prefix && has_suffix {
-        return val.contains(&item[1..item.len()-1]);
+        return val.contains(&item[1..item.len() - 1]);
     } else if has_prefix {
         return val.ends_with(&item[1..]);
     } else if has_suffix {
-        return val.starts_with(&item[..item.len()-1]);
+        return val.starts_with(&item[..item.len() - 1]);
     }
 
     item == val
 }
+
 pub trait GlobContains {
     fn glob_contains(&self, val: &Value) -> bool;
 }
@@ -114,12 +204,13 @@ impl GlobContains for Vec<Value> {
 }
 
 #[cfg(test)]
-mod test {
-    use super::*;
+mod mod_string_tests {
     use serde_json::json;
 
+    use super::*;
+
     #[test]
-    fn test_string() {
+    fn test_remove_duplicates() {
         let strings = vec![
             String::from("Orange"),
             String::from("Apple"),
@@ -158,39 +249,8 @@ mod test {
     }
 
     #[test]
-    fn test_globbed_strings_match() {
-        assert!(globbed_strings_match("exact", "exact"));
-        assert!(!globbed_strings_match("exact", "notexact"));
-
-        assert!(globbed_strings_match("pre*", "prefix"));
-        assert!(!globbed_strings_match("pre*", "noprefix"));
-
-        assert!(globbed_strings_match("*suf", "endsuf"));
-        assert!(!globbed_strings_match("*suf", "nosuffix"));
-
-        assert!(globbed_strings_match("*mid*", "inmiddle"));
-        assert!(!globbed_strings_match("*mid*", "none"));
-
-        assert!(globbed_strings_match("", ""));
-        assert!(!globbed_strings_match("", "nonempty"));
-
-        assert!(globbed_strings_match("a", "a"));
-        assert!(!globbed_strings_match("b", "a"));
-        assert!(!globbed_strings_match("a", "b"));
-
-        assert!(globbed_strings_match("nowild", "nowild"));
-        assert!(!globbed_strings_match("nowild", "wildhere"));
-    }
-
-    #[test]
     fn test_glob_contains() {
-        let patterns: Vec<Value> = vec![
-            json!("*abc*"),
-            json!("*def"),
-            json!("ghi*"),
-            json!("jkl"),
-            json!("m*n*o"),
-        ];
+        let patterns: Vec<Value> = vec![json!("*abc*"), json!("*def"), json!("ghi*"), json!("jkl"), json!("m*n*o")];
         let empty_patterns: Vec<Value> = vec![];
 
         assert_eq!(empty_patterns.glob_contains(&json!("any_string")), true);
@@ -213,18 +273,59 @@ mod test {
         assert_eq!(patterns.glob_contains(&json!({"key": "value"})), false);
         assert_eq!(patterns.glob_contains(&json!([1, 2, 3])), false);
 
-        let mixed_patterns: Vec<Value> = vec![
-            json!("*abc*"),
-            json!(42),
-            json!(true),
-            json!({"key": "value"}),
-            json!([1, 2, 3]),
-        ];
+        let mixed_patterns: Vec<Value> =
+            vec![json!("*abc*"), json!(42), json!(true), json!({"key": "value"}), json!([1, 2, 3])];
 
         assert_eq!(mixed_patterns.glob_contains(&json!("defabcghi")), true); // *abc*
         assert_eq!(mixed_patterns.glob_contains(&json!(42)), true); // 42
         assert_eq!(mixed_patterns.glob_contains(&json!(true)), true); // true
         assert_eq!(mixed_patterns.glob_contains(&json!({"key": "value"})), true); // {"key": "value"}
         assert_eq!(mixed_patterns.glob_contains(&json!([1, 2, 3])), true); // [1, 2, 3]
+    }
+
+    #[test]
+    fn test_ensure_trailing_slash() {
+        assert_eq!(ensure_trailing_slash("example"), "example/");
+        assert_eq!(ensure_trailing_slash("example/"), "example/");
+        assert_eq!(ensure_trailing_slash(""), "");
+    }
+
+    #[test]
+    fn test_ensure_no_trailing_slash() {
+        assert_eq!(ensure_no_trailing_slash("example/"), "example");
+        assert_eq!(ensure_no_trailing_slash("example"), "example");
+        assert_eq!(ensure_no_trailing_slash(""), "");
+    }
+
+    #[test]
+    fn test_ensure_no_leading_slash() {
+        assert_eq!(ensure_no_leading_slash("/example"), "example");
+        assert_eq!(ensure_no_leading_slash("example"), "example");
+        assert_eq!(ensure_no_leading_slash(""), "");
+    }
+
+    #[test]
+    fn test_globbed_strings_match() {
+        assert!(globbed_strings_match("exact", "exact"));
+        assert!(!globbed_strings_match("exact", "notexact"));
+
+        assert!(globbed_strings_match("pre*", "prefix"));
+        assert!(!globbed_strings_match("pre*", "noprefix"));
+
+        assert!(globbed_strings_match("*suf", "endsuf"));
+        assert!(!globbed_strings_match("*suf", "nosuffix"));
+
+        assert!(globbed_strings_match("*mid*", "inmiddle"));
+        assert!(!globbed_strings_match("*mid*", "none"));
+
+        assert!(globbed_strings_match("", ""));
+        assert!(!globbed_strings_match("", "nonempty"));
+
+        assert!(globbed_strings_match("a", "a"));
+        assert!(!globbed_strings_match("b", "a"));
+        assert!(!globbed_strings_match("a", "b"));
+
+        assert!(globbed_strings_match("nowild", "nowild"));
+        assert!(!globbed_strings_match("nowild", "wildhere"));
     }
 }

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use serde_json::Value;
+
 pub fn remove_duplicates(strings: &mut Vec<String>, stable: bool, lowercase: bool) {
     if stable {
         let mut seen = HashSet::new();
@@ -63,9 +65,58 @@ pub fn ensure_no_leading_slash(s: &str) -> String {
     result
 }
 
+pub fn globbed_strings_match(item: &str, val: &str) -> bool {
+    if item.len() < 2 {
+        return item == val;
+    }
+
+    let has_prefix = item.starts_with("*");
+    let has_suffix = item.ends_with("*");
+
+    if has_prefix && has_suffix {
+        return val.contains(&item[1..item.len()-1]);
+    } else if has_prefix {
+        return val.ends_with(&item[1..]);
+    } else if has_suffix {
+        return val.starts_with(&item[..item.len()-1]);
+    }
+
+    item == val
+}
+pub trait GlobContains {
+    fn glob_contains(&self, val: &Value) -> bool;
+}
+
+impl GlobContains for &Vec<Value> {
+    fn glob_contains(&self, val: &Value) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        for item in self.iter() {
+            if item.is_string() {
+                if globbed_strings_match(item.as_str().unwrap(), val.as_str().unwrap_or_default()) {
+                    return true;
+                }
+            } else {
+                return self.contains(val);
+            }
+        }
+
+        false
+    }
+}
+
+impl GlobContains for Vec<Value> {
+    fn glob_contains(&self, val: &Value) -> bool {
+        (&self).glob_contains(val)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_string() {
@@ -104,5 +155,76 @@ mod test {
             strings4,
             vec!["Apple".to_string(), "Orange".to_string(), "banana".to_string(), "orange".to_string()]
         );
+    }
+
+    #[test]
+    fn test_globbed_strings_match() {
+        assert!(globbed_strings_match("exact", "exact"));
+        assert!(!globbed_strings_match("exact", "notexact"));
+
+        assert!(globbed_strings_match("pre*", "prefix"));
+        assert!(!globbed_strings_match("pre*", "noprefix"));
+
+        assert!(globbed_strings_match("*suf", "endsuf"));
+        assert!(!globbed_strings_match("*suf", "nosuffix"));
+
+        assert!(globbed_strings_match("*mid*", "inmiddle"));
+        assert!(!globbed_strings_match("*mid*", "none"));
+
+        assert!(globbed_strings_match("", ""));
+        assert!(!globbed_strings_match("", "nonempty"));
+
+        assert!(globbed_strings_match("a", "a"));
+        assert!(!globbed_strings_match("b", "a"));
+        assert!(!globbed_strings_match("a", "b"));
+
+        assert!(globbed_strings_match("nowild", "nowild"));
+        assert!(!globbed_strings_match("nowild", "wildhere"));
+    }
+
+    #[test]
+    fn test_glob_contains() {
+        let patterns: Vec<Value> = vec![
+            json!("*abc*"),
+            json!("*def"),
+            json!("ghi*"),
+            json!("jkl"),
+            json!("m*n*o"),
+        ];
+        let empty_patterns: Vec<Value> = vec![];
+
+        assert_eq!(empty_patterns.glob_contains(&json!("any_string")), true);
+
+        assert_eq!(patterns.glob_contains(&json!("defabcghi")), true); // *abc*
+        assert_eq!(patterns.glob_contains(&json!("def")), true); // *def
+        assert_eq!(patterns.glob_contains(&json!("ghijkl")), true); // ghi*
+        assert_eq!(patterns.glob_contains(&json!("jkl")), true); // jkl
+
+        assert_eq!(patterns.glob_contains(&json!("mnop")), false);
+        assert_eq!(patterns.glob_contains(&json!("xyz")), false);
+        assert_eq!(patterns.glob_contains(&json!("ab")), false);
+        assert_eq!(patterns.glob_contains(&json!("efg")), false);
+        assert_eq!(patterns.glob_contains(&json!("hij")), false);
+        assert_eq!(patterns.glob_contains(&json!("k")), false);
+        assert_eq!(patterns.glob_contains(&json!("lmn")), false);
+
+        assert_eq!(patterns.glob_contains(&json!(42)), false);
+        assert_eq!(patterns.glob_contains(&json!(true)), false);
+        assert_eq!(patterns.glob_contains(&json!({"key": "value"})), false);
+        assert_eq!(patterns.glob_contains(&json!([1, 2, 3])), false);
+
+        let mixed_patterns: Vec<Value> = vec![
+            json!("*abc*"),
+            json!(42),
+            json!(true),
+            json!({"key": "value"}),
+            json!([1, 2, 3]),
+        ];
+
+        assert_eq!(mixed_patterns.glob_contains(&json!("defabcghi")), true); // *abc*
+        assert_eq!(mixed_patterns.glob_contains(&json!(42)), true); // 42
+        assert_eq!(mixed_patterns.glob_contains(&json!(true)), true); // true
+        assert_eq!(mixed_patterns.glob_contains(&json!({"key": "value"})), true); // {"key": "value"}
+        assert_eq!(mixed_patterns.glob_contains(&json!([1, 2, 3])), true); // [1, 2, 3]
     }
 }

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -24,6 +24,45 @@ pub fn remove_duplicates(strings: &mut Vec<String>, stable: bool, lowercase: boo
     }
 }
 
+pub fn ensure_trailing_slash(s: &str) -> String {
+    let s = s.trim();
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut result = s.to_string();
+    while !result.is_empty() && !result.ends_with('/') {
+        result.push('/');
+    }
+    result
+}
+
+pub fn ensure_no_trailing_slash(s: &str) -> String {
+    let s = s.trim();
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut result = s.to_string();
+    while !result.is_empty() && result.ends_with('/') {
+        result.pop();
+    }
+    result
+}
+
+pub fn ensure_no_leading_slash(s: &str) -> String {
+    let s = s.trim();
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut result = s.to_string();
+    while !result.is_empty() && result.starts_with('/') {
+        result.remove(0);
+    }
+    result
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/utils/token_util.rs
+++ b/src/utils/token_util.rs
@@ -194,6 +194,7 @@ impl TokenParams {
         auth.ttl = self.token_ttl;
         auth.max_ttl = self.token_max_ttl;
         auth.policies = self.token_policies.clone();
+        auth.no_default_policy = self.token_no_default_policy;
         auth.renewable = true;
     }
 }


### PR DESCRIPTION
1. Implemented basic policy storage & fundamental ACL features.
2. Upgraded hcl-rs to version 0.18 and implemented a format compatible with vault policy.