### PR TITLE
Exclude docs directory when packaging  @InfoHunter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_vault"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ RustyVault's RESTful API is designed to be fully compatible with Hashicorp Vault
 repository = "https://github.com/Tongsuo-Project/RustyVault"
 documentation = "https://docs.rs/rusty_vault/latest/rusty_vault/"
 build = "build.rs"
+exclude = [
+    "docs/*",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Otherwise crates.io will complain that the package is too large (more than 10MB)...