### PR TITLE
Bugfix.

### DIFF
--- a/src/http/sys.rs
+++ b/src/http/sys.rs
@@ -57,6 +57,13 @@ struct RemountRequest {
     to: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PolicyRequest {
+    #[serde(default)]
+    name: String,
+    policy: String,
+}
+
 fn response_seal_status(core: web::Data<Arc<RwLock<Core>>>) -> Result<HttpResponse, RvError> {
     let core = core.read()?;
 
@@ -259,6 +266,74 @@ async fn sys_auth_disable_request_handler(
     handle_request(core, &mut r).await
 }
 
+async fn sys_list_policies_request_handler(
+    req: HttpRequest,
+    core: web::Data<Arc<RwLock<Core>>>,
+) -> Result<HttpResponse, RvError> {
+    let mut r = request_auth(&req);
+    r.path = "sys/policy".to_string();
+    r.operation = Operation::List;
+
+    handle_request(core, &mut r).await
+}
+
+async fn sys_read_policy_request_handler(
+    req: HttpRequest,
+    name: web::Path<String>,
+    core: web::Data<Arc<RwLock<Core>>>,
+) -> Result<HttpResponse, RvError> {
+    let policy_name = name.into_inner();
+
+    let mut r = request_auth(&req);
+    r.path = "sys/policy/".to_owned() + policy_name.as_str();
+    r.operation = Operation::Read;
+
+    if policy_name.is_empty() {
+        r.operation = Operation::List;
+    }
+
+    handle_request(core, &mut r).await
+}
+
+async fn sys_write_policy_request_handler(
+    req: HttpRequest,
+    name: web::Path<String>,
+    mut body: web::Bytes,
+    core: web::Data<Arc<RwLock<Core>>>,
+) -> Result<HttpResponse, RvError> {
+    let _test = serde_json::from_slice::<PolicyRequest>(&body)?;
+    let payload = serde_json::from_slice(&body)?;
+    body.clear();
+    let policy_name = name.into_inner();
+    if policy_name.is_empty() {
+        return Ok(response_error(StatusCode::NOT_FOUND, ""));
+    }
+
+    let mut r = request_auth(&req);
+    r.path = "sys/policy/".to_owned() + policy_name.as_str();
+    r.operation = Operation::Write;
+    r.body = Some(payload);
+
+    handle_request(core, &mut r).await
+}
+
+async fn sys_delete_policy_request_handler(
+    req: HttpRequest,
+    name: web::Path<String>,
+    core: web::Data<Arc<RwLock<Core>>>,
+) -> Result<HttpResponse, RvError> {
+    let policy_name = name.into_inner();
+    if policy_name.is_empty() {
+        return Ok(response_error(StatusCode::NOT_FOUND, ""));
+    }
+
+    let mut r = request_auth(&req);
+    r.path = "sys/policy/".to_owned() + policy_name.as_str();
+    r.operation = Operation::Delete;
+
+    handle_request(core, &mut r).await
+}
+
 pub fn init_sys_service(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/v1/sys")
@@ -297,6 +372,13 @@ pub fn init_sys_service(cfg: &mut web::ServiceConfig) {
                     .route(web::get().to(sys_list_auth_mounts_request_handler))
                     .route(web::post().to(sys_auth_enable_request_handler))
                     .route(web::delete().to(sys_auth_disable_request_handler)),
+            )
+            .service(web::resource("/policy").route(web::get().to(sys_list_policies_request_handler)))
+            .service(
+                web::resource("/policy/{name:.*}")
+                    .route(web::get().to(sys_read_policy_request_handler))
+                    .route(web::post().to(sys_write_policy_request_handler))
+                    .route(web::delete().to(sys_delete_policy_request_handler)),
             ),
     );
 }

--- a/src/logical/auth.rs
+++ b/src/logical/auth.rs
@@ -28,6 +28,7 @@ pub struct Auth {
     pub policies: Vec<String>,
 
     // token_policies break down the list in policies to help determine where a policy was sourced
+    #[serde(default)]
     pub token_policies: Vec<String>,
 
     // Indicates that the default policy should not be added by core when creating a token.

--- a/src/modules/credential/userpass/path_users.rs
+++ b/src/modules/credential/userpass/path_users.rs
@@ -27,10 +27,11 @@ pub struct UserEntry {
     pub ttl: Duration,
     #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
     pub max_ttl: Duration,
-    #[serde(flatten)]
+    #[serde(flatten, default)]
     #[deref]
     #[deref_mut]
     pub token_params: TokenParams,
+    #[serde(default)]
     pub bound_cidrs: Vec<SockAddrMarshaler>,
 }
 

--- a/src/modules/policy/policy_store.rs
+++ b/src/modules/policy/policy_store.rs
@@ -57,7 +57,7 @@ const POLICY_CACHE_SIZE: usize = 1024;
 
 // DEFAULT_POLICY_NAME is the name of the default policy
 const DEFAULT_POLICY_NAME: &str = "default";
-static DEFAULT_POLICY: &str = r#"
+pub static DEFAULT_POLICY: &str = r#"
 # Allow tokens to look up their own properties
 path "auth/token/lookup-self" {
     capabilities = ["read"]

--- a/src/utils/token_util.rs
+++ b/src/utils/token_util.rs
@@ -17,35 +17,40 @@ const MAX_LEASE_TTL: Duration = Duration::from_secs(365 * 24 * 60 * 60 as u64);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenParams {
+    #[serde(default)]
     pub token_type: String,
 
     // The TTL to user for the token
-    #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
+    #[serde(default, serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
     pub token_ttl: Duration,
 
     // The max TTL to use for the token
-    #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
+    #[serde(default, serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
     pub token_max_ttl: Duration,
 
     // If set, the token entry will have an explicit maximum TTL set, rather than deferring to role/mount values
-    #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
+    #[serde(default, serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
     pub token_explicit_max_ttl: Duration,
 
     // If non-zero, tokens created using this role will be able to be renewed forever,
     // but will have a fixed renewal period of this value
-    #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
+    #[serde(default, serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
     pub token_period: Duration,
 
     // If set, core will not automatically add default to the policy list
+    #[serde(default)]
     pub token_no_default_policy: bool,
 
     // The maximum number of times a token issued from this role may be used.
+    #[serde(default)]
     pub token_num_uses: u64,
 
     // The policies to set
+    #[serde(default)]
     pub token_policies: Vec<String>,
 
     // The set of CIDRs that tokens generated using this role will be bound to
+    #[serde(default)]
     pub token_bound_cidrs: Vec<SockAddrMarshaler>,
 }
 


### PR DESCRIPTION
1. Fix the error caused by the absence of the newly added token_policies/token_params/bound_cidrs field in old data during Auth/UserEntry information deserialization.
2. Fix the bug of policy interface not being exposed to HTTP interface layer.