### PR TITLE
Make it mandatory to use rust-tongsuo instead of rust-openssl

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,13 +62,6 @@ jobs:
         make install
         popd
     - uses: actions/checkout@v3
-    - name: Configure the Cargo.toml to depend on the tongsuo library.
-      run : |
-        pwd
-        echo '[patch.crates-io]' >> ./Cargo.toml
-        echo 'openssl = { git = "https://github.com/Tongsuo-Project/rust-tongsuo.git" }' >> ./Cargo.toml
-        echo 'openssl-sys = { git = "https://github.com/Tongsuo-Project/rust-tongsuo.git" }' >> ./Cargo.toml
-        cargo update
     - name: Build
       run : |
         export LD_LIBRARY_PATH=${RUNNER_TEMP}/tongsuo/lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,13 +80,13 @@ priority-queue = "2.1"
 crossbeam-channel = "0.5"
 
 # optional dependencies
-openssl = { version = "0.10.64", optional = true }
-openssl-sys = { version = "0.9.102", optional = true }
+openssl = { version = "*", optional = true }
+openssl-sys = { version = "*", optional = true }
 
-# uncomment the following lines to use Tongsuo as underlying crypto adaptor
-#[patch.crates-io]
-#openssl = { git = "https://github.com/Tongsuo-Project/rust-tongsuo.git" }
-#openssl-sys = { git = "https://github.com/Tongsuo-Project/rust-tongsuo.git" }
+# rust-tongsuo is a superset of rust-openssl, so we can use it mandatorily anyway.
+[patch.crates-io]
+openssl = { git = "https://github.com/Tongsuo-Project/rust-tongsuo.git" }
+openssl-sys = { git = "https://github.com/Tongsuo-Project/rust-tongsuo.git" }
 
 [build-dependencies]
 toml = "0.8.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_vault"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ RustyVault's RESTful API is designed to be fully compatible with Hashicorp Vault
 repository = "https://github.com/Tongsuo-Project/RustyVault"
 documentation = "https://docs.rs/rusty_vault/latest/rusty_vault/"
 build = "build.rs"
+exclude = [
+    "docs/*",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Since rust-tongsuo is a superset of rust-openssl, we can just make it used by default. This can resolve many version conflict problem between rust-tongsuo and rust-openssl.