### PR TITLE
Add sync_handler feature.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
       run: ulimit -n 65535
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests with sync_handler features
+      run: cargo test --features sync_handler --verbose
     - name: Run Clippy
       run: cargo clippy -- -D warnings
     - name: debug with ssh tunnel
@@ -72,6 +74,10 @@ jobs:
       run : |
         export LD_LIBRARY_PATH=${RUNNER_TEMP}/tongsuo/lib
         OPENSSL_DIR=${RUNNER_TEMP}/tongsuo RUSTFLAGS="-C link-args=-Wl,-rpath,${RUNNER_TEMP}/tongsuo/lib" cargo test --verbose --features crypto_adaptor_tongsuo --no-default-features
+    - name: Run tests with sync_handler features
+      run : |
+        export LD_LIBRARY_PATH=${RUNNER_TEMP}/tongsuo/lib
+        OPENSSL_DIR=${RUNNER_TEMP}/tongsuo RUSTFLAGS="-C link-args=-Wl,-rpath,${RUNNER_TEMP}/tongsuo/lib" cargo test --verbose --features crypto_adaptor_tongsuo --features sync_handler --no-default-features
     - name: debug with ssh tunnel
       if: ${{ failure() }}
       uses: wa5i/ssh-to-actions@main
@@ -131,6 +137,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests with sync_handler features
+      run: cargo test --features sync_handler --verbose
 
   windows-mysql-test:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ stretto = "0.8"
 itertools = "0.14"
 priority-queue = "2.1"
 crossbeam-channel = "0.5"
+maybe-async = { version = "0.2", optional = false }
 
 # optional dependencies
 openssl = { version = "*", optional = true }
@@ -96,6 +97,7 @@ default = ["crypto_adaptor_openssl"]
 storage_mysql = ["diesel", "r2d2", "r2d2-diesel"]
 crypto_adaptor_openssl = ["dep:openssl", "dep:openssl-sys"]
 crypto_adaptor_tongsuo = ["dep:openssl", "dep:openssl-sys"]
+sync_handler = ["maybe-async/is_sync"]
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"

--- a/src/core.rs
+++ b/src/core.rs
@@ -107,6 +107,7 @@ impl Default for Core {
     }
 }
 
+#[maybe_async::maybe_async]
 impl Core {
     pub fn config(&mut self, core: Arc<RwLock<Core>>, config: Option<&Config>) -> Result<(), RvError> {
         if let Some(conf) = config {
@@ -411,6 +412,7 @@ impl Core {
         Ok(())
     }
 
+    #[maybe_async::maybe_async]
     pub async fn handle_request(&self, req: &mut Request) -> Result<Option<Response>, RvError> {
         let mut resp = None;
         let mut err: Option<RvError> = None;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,7 +6,6 @@
 //! The `Handler` trait should be implemented in other module, such as the `rusty_vault::router`
 //! for instance.
 
-use async_trait::async_trait;
 use derive_more::Display;
 
 use crate::{
@@ -16,7 +15,7 @@ use crate::{
     logical::{request::Request, response::Response, Auth},
 };
 
-#[async_trait]
+#[maybe_async::maybe_async]
 pub trait Handler: Send + Sync {
     fn name(&self) -> String;
 
@@ -41,7 +40,7 @@ pub trait Handler: Send + Sync {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 pub trait AuthHandler: Send + Sync {
     fn name(&self) -> String;
 

--- a/src/http/logical.rs
+++ b/src/http/logical.rs
@@ -81,8 +81,12 @@ async fn logical_request_handler(
             r.operation = Operation::List;
         }
     }
+    #[cfg(feature = "sync_handler")]
+    let ret = core.read()?.handle_request(&mut r)?;
+    #[cfg(not(feature = "sync_handler"))]
+    let ret = core.read()?.handle_request(&mut r).await?;
 
-    match core.read()?.handle_request(&mut r).await? {
+    match ret {
         Some(resp) => response_logical(&resp, &r.path),
         None => {
             if matches!(r.operation, Operation::Read | Operation::List) {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -199,6 +199,9 @@ pub fn response_json_ok<T: Serialize>(cookie: Option<Cookie>, body: T) -> HttpRe
 
 pub async fn handle_request(core: web::Data<Arc<RwLock<Core>>>, req: &mut Request) -> Result<HttpResponse, RvError> {
     let core = core.read()?;
+    #[cfg(feature = "sync_handler")]
+    let resp = core.handle_request(req)?;
+    #[cfg(not(feature = "sync_handler"))]
     let resp = core.handle_request(req).await?;
     if resp.is_none() {
         Ok(response_ok(None, None))

--- a/src/modules/auth/token_store.rs
+++ b/src/modules/auth/token_store.rs
@@ -9,7 +9,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use async_trait::async_trait;
 use better_default::Default;
 use humantime::parse_duration;
 use lazy_static::lazy_static;
@@ -727,7 +726,7 @@ impl TokenStore {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 impl Handler for TokenStore {
     fn name(&self) -> String {
         "auth_token".to_string()

--- a/src/modules/credential/approle/mod.rs
+++ b/src/modules/credential/approle/mod.rs
@@ -216,6 +216,7 @@ mod test {
         test_utils::{test_delete_api, test_mount_auth_api, test_read_api, test_rusty_vault_init, test_write_api},
     };
 
+    #[maybe_async::maybe_async]
     pub async fn test_read_role(
         core: &Core,
         token: &str,
@@ -227,6 +228,7 @@ mod test {
         resp
     }
 
+    #[maybe_async::maybe_async]
     pub async fn test_write_role(
         core: &Core,
         token: &str,
@@ -257,12 +259,13 @@ mod test {
                 .await;
     }
 
+    #[maybe_async::maybe_async]
     pub async fn test_delete_role(core: &Core, token: &str, path: &str, role_name: &str) {
-        assert!(test_delete_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true, None)
-            .await
-            .is_ok());
+        let resp = test_delete_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true, None).await;
+        assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     pub async fn generate_secret_id(core: &Core, token: &str, path: &str, role_name: &str) -> (String, String) {
         let resp =
             test_write_api(core, token, format!("auth/{}/role/{}/secret-id", path, role_name).as_str(), true, None)
@@ -275,6 +278,7 @@ mod test {
         (secret_id.to_string(), secret_id_accessor.to_string())
     }
 
+    #[maybe_async::maybe_async]
     pub async fn test_login(
         core: &Core,
         path: &str,
@@ -308,6 +312,7 @@ mod test {
         resp
     }
 
+    #[maybe_async::maybe_async]
     async fn test_approle(core: &Core, token: &str, path: &str, role_name: &str) {
         // Create a role
         let resp = test_write_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true, None).await;
@@ -460,6 +465,7 @@ mod test {
         let _ = test_login(core, path, role_id, &secret_id, false).await;
     }
 
+    #[maybe_async::maybe_async]
     async fn test_approle_role_service(core: &Core, token: &str, path: &str, role_name: &str) {
         // Create a role
         let mut data = json!({
@@ -549,7 +555,7 @@ mod test {
         println!("resp_data: {:?}", resp_data);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_credential_approle_module() {
         let (root_token, core) = test_rusty_vault_init("test_approle_module");
         let core = core.read().unwrap();

--- a/src/modules/credential/approle/path_role.rs
+++ b/src/modules/credential/approle/path_role.rs
@@ -2209,7 +2209,7 @@ mod test {
         },
     };
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_read_local_secret_ids() {
         let (root_token, core) = test_rusty_vault_init("test_approle_read_local_secret_ids");
         let core = core.read().unwrap();
@@ -2235,7 +2235,7 @@ mod test {
         assert_eq!(resp_data["local_secret_ids"].as_bool().unwrap(), data["local_secret_ids"].as_bool().unwrap());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_local_non_secret_ids() {
         let (root_token, core) = test_rusty_vault_init("test_approle_local_non_secret_ids");
         let core = core.read().unwrap();
@@ -2269,9 +2269,8 @@ mod test {
         // Create secret IDs on testrole1
         let len = 10;
         for _i in 0..len {
-            assert!(test_write_api(&core, &root_token, "auth/approle/role/testrole1/secret-id", true, None)
-                .await
-                .is_ok());
+            let ret = test_write_api(&core, &root_token, "auth/approle/role/testrole1/secret-id", true, None).await;
+            assert!(ret.is_ok());
         }
 
         // Check the number of secret IDs generated
@@ -2282,9 +2281,8 @@ mod test {
 
         // Create secret IDs on testrole2
         for _i in 0..len {
-            assert!(test_write_api(&core, &root_token, "auth/approle/role/testrole2/secret-id", true, None)
-                .await
-                .is_ok());
+            let ret = test_write_api(&core, &root_token, "auth/approle/role/testrole2/secret-id", true, None).await;
+            assert!(ret.is_ok());
         }
 
         // Check the number of secret IDs generated
@@ -2294,7 +2292,7 @@ mod test {
         assert_eq!(resp_data["keys"].as_array().unwrap().len(), len);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_upgrade_secret_id_prefix() {
         let (root_token, core) = test_rusty_vault_init("test_approle_upgrade_secret_id_prefix");
         let core = core.read().unwrap();
@@ -2340,7 +2338,7 @@ mod test {
         assert!(!resp_data["local_secret_ids"].as_bool().unwrap());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_local_secret_id_immutablility() {
         let (root_token, core) = test_rusty_vault_init("test_approle_local_secret_id_immutablility");
         let core = core.read().unwrap();
@@ -2365,7 +2363,7 @@ mod test {
         let _ = test_write_api(&core, &root_token, "auth/approle/role/testrole", false, Some(data.clone())).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_upgrade_bound_cidr_list() {
         let (root_token, core) = test_rusty_vault_init("test_approle_upgrade_bound_cidr_list");
         let core = core.read().unwrap();
@@ -2436,7 +2434,7 @@ mod test {
         assert_ne!(secret_id, "");
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_name_lower_casing() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_name_lower_casing");
         let core = core.read().unwrap();
@@ -2575,7 +2573,7 @@ mod test {
         assert_eq!(keys.len(), 1);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_read_set_index() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_read_set_index");
         let core = core.read().unwrap();
@@ -2655,7 +2653,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_cidr_subset() {
         let (root_token, core) = test_rusty_vault_init("test_approle_cidr_subset");
         let core = core.read().unwrap();
@@ -2704,7 +2702,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_token_bound_cidr_subset_32_mask() {
         let (root_token, core) = test_rusty_vault_init("test_approle_token_bound_cidr_subset_32_mask");
         let core = core.read().unwrap();
@@ -2749,7 +2747,7 @@ mod test {
         assert!(resp.is_err());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_constraints() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_constraints");
         let core = core.read().unwrap();
@@ -2784,7 +2782,7 @@ mod test {
         assert!(resp.is_err());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_update_role_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_update_role_id");
         let core = core.read().unwrap();
@@ -2817,7 +2815,7 @@ mod test {
         let _ = test_login(&core, "approle", "customroleid", secret_id, true).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_id_uniqueness() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_id_uniqueness");
         let core = core.read().unwrap();
@@ -2875,7 +2873,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_delete_secret_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_delete_secret_id");
         let core = core.read().unwrap();
@@ -2899,7 +2897,7 @@ mod test {
         let _ = test_list_api(&core, &root_token, "auth/approle/role/role1/secret-id", false).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_lookup_and_destroy_role_secret_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_lookup_and_destroy_role_secret_id");
         let core = core.read().unwrap();
@@ -2946,7 +2944,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_lookup_and_destroy_role_secret_id_accessor() {
         let (root_token, core) = test_rusty_vault_init("test_approle_lookup_and_destroy_role_secret_id_accessor");
         let core = core.read().unwrap();
@@ -2999,7 +2997,7 @@ mod test {
         .await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_lookup_role_secret_id_accessor() {
         let (root_token, core) = test_rusty_vault_init("test_approle_lookup_role_secret_id_accessor");
         let core = core.read().unwrap();
@@ -3026,7 +3024,7 @@ mod test {
         // TODO: resp should ok
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_list_role_secret_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_list_role_secret_id");
         let core = core.read().unwrap();
@@ -3050,7 +3048,7 @@ mod test {
         assert_eq!(keys.len(), 5);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_list_role() {
         let (root_token, core) = test_rusty_vault_init("test_approle_list_role");
         let core = core.read().unwrap();
@@ -3074,7 +3072,7 @@ mod test {
         assert_eq!(expect.as_array().unwrap().clone(), keys);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_without_fields() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_without_fields");
         let core = core.read().unwrap();
@@ -3128,7 +3126,7 @@ mod test {
         assert_eq!(secret_id_num_uses, role_data["secret_id_num_uses"].as_int().unwrap());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_with_valid_fields() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_with_valid_fields");
         let core = core.read().unwrap();
@@ -3193,7 +3191,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_with_invalid_fields() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_with_invalid_fields");
         let core = core.read().unwrap();
@@ -3307,7 +3305,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_crud() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_crud");
         let core = core.read().unwrap();
@@ -3638,7 +3636,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_token_bound_cidrs_crud() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_token_bound_cidrs_crud");
         let core = core.read().unwrap();
@@ -3805,7 +3803,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_token_type_crud() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_token_type_crud");
         let core = core.read().unwrap();
@@ -3891,7 +3889,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_token_util_upgrade() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_token_util_upgrade");
         let core = core.read().unwrap();
@@ -4015,7 +4013,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_with_ttl() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_with_ttl");
         let core = core.read().unwrap();
@@ -4068,7 +4066,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_accessor_cross_delete() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_accessor_cross_delete");
         let core = core.read().unwrap();

--- a/src/modules/credential/approle/path_tidy_secret_id.rs
+++ b/src/modules/credential/approle/path_tidy_secret_id.rs
@@ -268,6 +268,9 @@ mod test {
         let c = core.read().unwrap();
 
         // Mount approle auth to path: auth/approle
+        #[cfg(feature = "sync_handler")]
+        test_mount_auth_api(&c, &root_token, "approle", "approle/");
+        #[cfg(not(feature = "sync_handler"))]
         test_mount_auth_api(&c, &root_token, "approle", "approle/").await;
 
         let module = c.module_manager.get_module("approle").unwrap();
@@ -294,7 +297,12 @@ mod test {
         req.operation = Operation::Write;
         req.path = "auth/approle/role/role1/secret-id".to_string();
         req.client_token = root_token.to_string();
+
+        #[cfg(feature = "sync_handler")]
+        let _resp = c.handle_request(&mut req);
+        #[cfg(not(feature = "sync_handler"))]
         let _resp = c.handle_request(&mut req).await;
+
         req.storage = c.get_system_view().map(|arc| arc as Arc<dyn Storage>);
 
         let mut mock_backend = approle_module.new_backend();
@@ -348,6 +356,9 @@ mod test {
         let c = core.read().unwrap();
 
         // Mount approle auth to path: auth/approle
+        #[cfg(feature = "sync_handler")]
+        test_mount_auth_api(&c, &root_token, "approle", "approle/");
+        #[cfg(not(feature = "sync_handler"))]
         test_mount_auth_api(&c, &root_token, "approle", "approle/").await;
 
         let module = c.module_manager.get_module("approle").unwrap();
@@ -377,7 +388,12 @@ mod test {
         req.operation = Operation::Write;
         req.path = "auth/approle/role/role1/secret-id".to_string();
         req.client_token = root_token.to_string();
+
+        #[cfg(feature = "sync_handler")]
+        let _resp = c.handle_request(&mut req);
+        #[cfg(not(feature = "sync_handler"))]
         let _resp = c.handle_request(&mut req).await;
+
         req.storage = c.get_system_view().map(|arc| arc as Arc<dyn Storage>);
         let resp = approle_module.write_role_secret_id(&mock_backend, &mut req);
         assert!(resp.is_ok());
@@ -407,7 +423,12 @@ mod test {
                 let mut req = Request::new("auth/approle/role/role1/secret-id");
                 req.operation = Operation::Write;
                 req.client_token = token.clone();
+
+                #[cfg(feature = "sync_handler")]
+                let _resp = c.handle_request(&mut req);
+                #[cfg(not(feature = "sync_handler"))]
                 let _resp = c.handle_request(&mut req).await;
+
                 req.storage = c.get_system_view().map(|arc| arc as Arc<dyn Storage>);
                 let resp = approle_module.write_role_secret_id(&mb, &mut req);
                 assert!(resp.is_ok());

--- a/src/modules/credential/userpass/mod.rs
+++ b/src/modules/credential/userpass/mod.rs
@@ -127,6 +127,7 @@ mod test {
         test_utils::{test_delete_api, test_mount_auth_api, test_read_api, test_rusty_vault_init, test_write_api},
     };
 
+    #[maybe_async::maybe_async]
     async fn test_write_user(core: &Core, token: &str, path: &str, username: &str, password: &str, ttl: i32) {
         let user_data = json!({
             "password": password,
@@ -142,18 +143,20 @@ mod test {
         assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_read_user(core: &Core, token: &str, username: &str) -> Result<Option<Response>, RvError> {
         let resp = test_read_api(core, token, format!("auth/pass/users/{}", username).as_str(), true).await;
         assert!(resp.is_ok());
         resp
     }
 
+    #[maybe_async::maybe_async]
     async fn test_delete_user(core: &Core, token: &str, username: &str) {
-        assert!(test_delete_api(core, token, format!("auth/pass/users/{}", username).as_str(), true, None)
-            .await
-            .is_ok());
+        let resp = test_delete_api(core, token, format!("auth/pass/users/{}", username).as_str(), true, None).await;
+        assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_login(
         core: &Core,
         path: &str,
@@ -181,7 +184,7 @@ mod test {
         resp
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_userpass_module() {
         let (root_token, core) = test_rusty_vault_init("test_userpass_module");
         let core = core.read().unwrap();

--- a/src/modules/pki/mod.rs
+++ b/src/modules/pki/mod.rs
@@ -151,6 +151,7 @@ mod test {
         test_utils::{test_delete_api, test_mount_api, test_read_api, test_rusty_vault_init, test_write_api},
     };
 
+    #[maybe_async::maybe_async]
     async fn config_ca(core: &Core, token: &str, path: &str) {
         let ca_pem_bundle = format!("{}{}", CA_CERT_PEM, CA_KEY_PEM);
 
@@ -166,6 +167,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn config_role(core: &Core, token: &str, path: &str, role_name: &str, key_type: &str, key_bits: u32) {
         let role_data = json!({
             "ttl": "60d",
@@ -183,11 +185,12 @@ mod test {
         .clone();
 
         // config role
-        assert!(test_write_api(core, token, format!("{}roles/{}", path, role_name).as_str(), true, Some(role_data))
-            .await
-            .is_ok());
+        let resp =
+            test_write_api(&core, token, format!("{}roles/{}", path, role_name).as_str(), true, Some(role_data)).await;
+        assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn generate_root(
         core: &Core,
         token: &str,
@@ -264,6 +267,7 @@ mod test {
         }
     }
 
+    #[maybe_async::maybe_async]
     async fn delete_root(core: &Core, token: &str, path: &str, is_ok: bool) {
         let resp = test_delete_api(core, token, format!("{}root", path).as_str(), is_ok, None).await;
         if !is_ok {
@@ -275,6 +279,7 @@ mod test {
         assert_eq!(resp_ca_pem.unwrap_err(), RvError::ErrPkiCaNotConfig);
     }
 
+    #[maybe_async::maybe_async]
     async fn issue_cert_by_generate_root(
         core: &Core,
         token: &str,
@@ -397,7 +402,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
 2k24wuH7oUtLlvf05p4cqfEx
 -----END PRIVATE KEY-----"#;
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_config_ca() {
         let (root_token, c) = test_rusty_vault_init("test_pki_config_ca");
         let token = &root_token;
@@ -427,7 +432,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         assert_eq!(resp_ca_cert_data["certificate"].as_str().unwrap().trim(), CA_CERT_PEM.trim());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_config_role() {
         let (root_token, c) = test_rusty_vault_init("test_pki_config_role");
         let token = &root_token;
@@ -465,7 +470,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         assert_eq!(role_data["no_store"].as_bool().unwrap(), false);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_issue_cert() {
         let (root_token, c) = test_rusty_vault_init("test_pki_issue_cert");
         let token = &root_token;
@@ -565,7 +570,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         );
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_generate_root() {
         let (root_token, c) = test_rusty_vault_init("test_pki_generate_root");
         let token = &root_token;
@@ -591,7 +596,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
     }
 
     #[cfg(feature = "crypto_adaptor_tongsuo")]
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_sm2_generate_root() {
         let (root_token, c) = test_rusty_vault_init("test_pki_generate_root");
         let token = &root_token;
@@ -616,6 +621,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         delete_root(&core, token, path, true).await;
     }
 
+    #[maybe_async::maybe_async]
     async fn test_pki_generate_key_case(
         core: &Core,
         token: &str,
@@ -681,6 +687,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         }
     }
 
+    #[maybe_async::maybe_async]
     async fn test_pki_import_key_case(
         core: &Core,
         token: &str,
@@ -727,6 +734,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         assert_eq!(key_data["key_bits"].as_u64().unwrap(), key_bits as u64);
     }
 
+    #[maybe_async::maybe_async]
     async fn test_pki_sign_verify(core: &Core, token: &str, path: &str, key_name: &str, data: &[u8], is_ok: bool) {
         let req_data = json!({
             "key_name": key_name.to_string(),
@@ -812,9 +820,11 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         .as_object()
         .unwrap()
         .clone();
-        assert!(test_write_api(core, token, &format!("{}/keys/verify", path), false, Some(req_data)).await.is_err());
+        let resp = test_write_api(core, token, &format!("{}/keys/verify", path), false, Some(req_data)).await;
+        assert!(resp.is_err());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_pki_encrypt_decrypt(core: &Core, token: &str, path: &str, key_name: &str, data: &[u8], is_ok: bool) {
         let origin_data = hex::encode(data);
         let req_data = json!({
@@ -863,10 +873,11 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
         .as_object()
         .unwrap()
         .clone();
-        assert!(test_write_api(core, token, &format!("{}/keys/decrypt", path), false, Some(req_data)).await.is_err());
+        let resp = test_write_api(core, token, &format!("{}/keys/decrypt", path), false, Some(req_data)).await;
+        assert!(resp.is_err());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_generate_key() {
         let (root_token, c) = test_rusty_vault_init("test_pki_generate_key");
         let token = &root_token;
@@ -968,7 +979,7 @@ x/+V28hUf8m8P2NxP5ALaDZagdaMfzjGZo3O3wDv33Cds0P5GMGQYnRXDxcZN/2L
             .await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_pki_import_key() {
         let (root_token, c) = test_rusty_vault_init("test_pki_import_key");
         let token = &root_token;

--- a/src/modules/policy/mod.rs
+++ b/src/modules/policy/mod.rs
@@ -152,6 +152,7 @@ mod mod_policy_tests {
         },
     };
 
+    #[maybe_async::maybe_async]
     async fn test_write_policy(core: &Core, token: &str, name: &str, policy: &str) {
         let data = json!({
             "policy": policy,
@@ -164,16 +165,20 @@ mod mod_policy_tests {
         assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_read_policy(core: &Core, token: &str, name: &str) -> Result<Option<Response>, RvError> {
         let resp = test_read_api(core, token, format!("sys/policy/{}", name).as_str(), true).await;
         assert!(resp.is_ok());
         resp
     }
 
+    #[maybe_async::maybe_async]
     async fn test_delete_policy(core: &Core, token: &str, name: &str) {
-        assert!(test_delete_api(core, token, format!("sys/policy/{}", name).as_str(), true, None).await.is_ok());
+        let resp = test_delete_api(core, token, format!("sys/policy/{}", name).as_str(), true, None).await;
+        assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_write_user(
         core: &Core,
         token: &str,
@@ -198,6 +203,7 @@ mod mod_policy_tests {
         assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_user_login(
         core: &Core,
         path: &str,
@@ -225,7 +231,7 @@ mod mod_policy_tests {
         resp
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_policy_curd_api() {
         let (root_token, core) = test_rusty_vault_init("test_policy_curd_api");
         let core = core.read().unwrap();
@@ -277,7 +283,7 @@ mod mod_policy_tests {
         assert_eq!(policies["policies"], json!(["default", "root"]));
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_policy_http_api() {
         let mut test_http_server = TestHttpServer::new("test_policy_http_api", true);
 
@@ -332,7 +338,7 @@ mod mod_policy_tests {
         assert_eq!(ret.unwrap().1, json!({"keys": ["default", "root"], "policies": ["default", "root"]}));
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_policy_acl_check() {
         let (root_token, core) = test_rusty_vault_init("test_policy_acl_check");
         let core = core.read().unwrap();
@@ -426,7 +432,7 @@ mod mod_policy_tests {
         assert!(resp.is_err());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_policy_acl_check_with_policy_parameters() {
         let (root_token, core) = test_rusty_vault_init("test_policy_acl_check_with_policy_parameters");
         let core = core.read().unwrap();

--- a/src/modules/policy/policy_store.rs
+++ b/src/modules/policy/policy_store.rs
@@ -23,7 +23,6 @@ use std::{
     sync::{Arc, RwLock, Weak},
 };
 
-use async_trait::async_trait;
 use better_default::Default;
 use dashmap::DashMap;
 use lazy_static::lazy_static;
@@ -629,7 +628,7 @@ impl PolicyStore {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 impl AuthHandler for PolicyStore {
     fn name(&self) -> String {
         "policy_store".to_string()

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,7 +4,6 @@
 
 use std::sync::{Arc, RwLock};
 
-use async_trait::async_trait;
 use radix_trie::{Trie, TrieCommon};
 
 use crate::{
@@ -249,7 +248,7 @@ impl Router {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 impl Handler for Router {
     fn name(&self) -> String {
         "core_router".to_string()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1131,6 +1131,7 @@ pub fn start_test_http_server_with_prometheus(
     server_thread
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool) -> Result<Option<Response>, RvError> {
     let mut req = Request::new(path);
     req.operation = Operation::List;
@@ -1141,6 +1142,7 @@ pub async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool) ->
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool) -> Result<Option<Response>, RvError> {
     let mut req = Request::new(path);
     req.operation = Operation::Read;
@@ -1151,6 +1153,7 @@ pub async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool) ->
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_write_api(
     core: &Core,
     token: &str,
@@ -1169,6 +1172,7 @@ pub async fn test_write_api(
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_delete_api(
     core: &Core,
     token: &str,
@@ -1186,6 +1190,7 @@ pub async fn test_delete_api(
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_mount_api(core: &Core, token: &str, mtype: &str, path: &str) {
     let data = json!({
         "type": mtype,
@@ -1198,6 +1203,7 @@ pub async fn test_mount_api(core: &Core, token: &str, mtype: &str, path: &str) {
     assert!(resp.is_ok());
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_mount_auth_api(core: &Core, token: &str, atype: &str, path: &str) {
     let auth_data = json!({
         "type": atype,

--- a/tests/test_default_logical.rs
+++ b/tests/test_default_logical.rs
@@ -13,6 +13,7 @@ use rusty_vault::{
 };
 use serde_json::{json, Map, Value};
 
+#[maybe_async::maybe_async]
 async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool, expect: Option<Map<String, Value>>) {
     let mut req = Request::new(path);
     req.operation = Operation::Read;
@@ -29,22 +30,30 @@ async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool, expect
     }
 }
 
+#[maybe_async::maybe_async]
 async fn test_write_api(core: &Core, token: &str, path: &str, is_ok: bool, data: Option<Map<String, Value>>) {
     let mut req = Request::new(path);
     req.operation = Operation::Write;
     req.client_token = token.to_string();
     req.body = data;
 
-    assert_eq!(core.handle_request(&mut req).await.is_ok(), is_ok);
+    let ret = core.handle_request(&mut req).await;
+
+    assert_eq!(ret.is_ok(), is_ok);
 }
 
+#[maybe_async::maybe_async]
 async fn test_delete_api(core: &Core, token: &str, path: &str, is_ok: bool) {
     let mut req = Request::new(path);
     req.operation = Operation::Delete;
     req.client_token = token.to_string();
-    assert_eq!(core.handle_request(&mut req).await.is_ok(), is_ok);
+
+    let ret = core.handle_request(&mut req).await;
+
+    assert_eq!(ret.is_ok(), is_ok);
 }
 
+#[maybe_async::maybe_async]
 async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool, keys_len: usize) {
     let mut req = Request::new(path);
     req.operation = Operation::List;
@@ -60,6 +69,7 @@ async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool, keys_l
     }
 }
 
+#[maybe_async::maybe_async]
 async fn test_default_secret(core: Arc<RwLock<Core>>, token: &str) {
     let core = core.read().unwrap();
 
@@ -82,6 +92,7 @@ async fn test_default_secret(core: Arc<RwLock<Core>>, token: &str) {
     test_list_api(&core, token, "secret/", true, 1).await;
 }
 
+#[maybe_async::maybe_async]
 async fn test_kv_logical_backend(core: Arc<RwLock<Core>>, token: &str) {
     let core = core.read().unwrap();
 
@@ -166,6 +177,7 @@ async fn test_kv_logical_backend(core: Arc<RwLock<Core>>, token: &str) {
     test_read_api(&core, token, "vk/foo", false, None).await;
 }
 
+#[maybe_async::maybe_async]
 async fn test_sys_mount_feature(core: Arc<RwLock<Core>>, token: &str) {
     let core = core.read().unwrap();
 
@@ -253,6 +265,7 @@ async fn test_sys_mount_feature(core: Arc<RwLock<Core>>, token: &str) {
     test_write_api(&core, token, "sys/remount", true, Some(remount_data)).await;
 }
 
+#[maybe_async::maybe_async]
 async fn test_sys_raw_api_feature(core: Arc<RwLock<Core>>, token: &str) {
     let core = core.read().unwrap();
 
@@ -295,12 +308,13 @@ async fn test_sys_raw_api_feature(core: Arc<RwLock<Core>>, token: &str) {
     test_read_api(&core, token, "sys/raw/test", true, None).await;
 }
 
+#[maybe_async::maybe_async]
 async fn test_sys_logical_backend(core: Arc<RwLock<Core>>, token: &str) {
     test_sys_mount_feature(Arc::clone(&core), token).await;
     test_sys_raw_api_feature(core, token).await;
 }
 
-#[tokio::test]
+#[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
 async fn test_default_logical() {
     let dir = env::temp_dir().join("rusty_vault_core_init");
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
When `rusty_vault` is used as a crate, the `core.handle_request` async function may cause integration issues in some projects. This commit introduces a new feature flag `--features sync_handler` to control whether the handler processing function should be synchronous. By default, the handler remains asynchronous.