### PR TITLE
fix: better error for cli server

### DIFF
--- a/src/cli/command/server.rs
+++ b/src/cli/command/server.rs
@@ -59,7 +59,7 @@ impl Server {
                 Ok(_) => EXIT_CODE_OK,
                 Err(e) => {
                     println!("server error: {:?}", e);
-                    EXIT_CODE_LOAD_CONFIG_FAILURE
+                    std::process::exit(EXIT_CODE_LOAD_CONFIG_FAILURE as i32);
                 }
             };
         }


### PR DESCRIPTION
for server cli if the config raise error the output will always output all the usage
and hard to check.
this patch fix it using process exit.

before this patch:

![image](https://github.com/user-attachments/assets/10d1028e-361f-4d4f-b975-771bbe97560c)

after this patch:
![image](https://github.com/user-attachments/assets/54d12979-fd1a-4843-a166-025abd04c956)
