### PR TITLE
Optimize auth module timer implementation to reduce resource consumption for v0.2.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v0.2" ]
     paths-ignore:
       - "docs/**"
       - ".github/workflows/website.yml"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,7 +151,7 @@ jobs:
       run: vcpkg install openssl:x64-windows-static-md
     - name: Download MySQL Connector/C
       run: |
-        Invoke-WebRequest -Uri "https://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.11-winx64.msi" -OutFile "mysql-connector.msi"
+        Invoke-WebRequest -Uri "https://cdn.mysql.com/Downloads/Connector-C/mysql-connector-c-6.1.11-winx64.msi" -OutFile "mysql-connector.msi"
     - name: Install MySQL Connector/C
       run: |
         Start-Process msiexec.exe -ArgumentList '/i', 'mysql-connector.msi', '/quiet', '/norestart' -NoNewWindow -Wait

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ log = "0.4"
 env_logger = "0.10"
 hex = "0.4"
 humantime = "2.1"
-delay_timer = "0.11.6"
 as-any = "0.3.1"
 pem = "3.0"
 chrono = "0.4"
@@ -78,6 +77,7 @@ async-trait = "0.1"
 stretto = "0.8"
 itertools = "0.14"
 priority-queue = "2.1"
+crossbeam-channel = "0.5"
 
 # optional dependencies
 openssl = { version = "0.10.64", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ sysinfo = "0.31.4"
 prettytable = "0.10"
 rpassword = "7.3"
 async-trait = "0.1"
+stretto = "0.8"
+itertools = "0.14"
+priority-queue = "2.1"
 
 # optional dependencies
 openssl = { version = "0.10.64", optional = true }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,20 +3,24 @@
 
 use std::{
     any::Any,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use dashmap::DashMap;
+use tokio::task::JoinHandle;
 
-#[derive(Debug)]
+use crate::errors::RvError;
+
+#[derive(Default, Debug)]
 pub struct Context {
+    tasks: Mutex<Vec<JoinHandle<()>>>,
     data_map: DashMap<String, Arc<dyn Any + Send + Sync>>,
     data_map_mut: DashMap<String, Arc<RwLock<dyn Any + Send + Sync>>>,
 }
 
 impl Context {
     pub fn new() -> Self {
-        Self { data_map: DashMap::new(), data_map_mut: DashMap::new() }
+        Self { data_map: DashMap::new(), data_map_mut: DashMap::new(), ..Default::default() }
     }
 
     pub fn set_mut(&self, key: &str, data: Arc<RwLock<dyn Any + Send + Sync>>) {
@@ -33,5 +37,24 @@ impl Context {
 
     pub fn get(&self, key: &str) -> Option<Arc<dyn Any + Send + Sync>> {
         self.data_map.get(key).map(|r| Arc::clone(&*r))
+    }
+
+    pub fn add_task(&self, task: JoinHandle<()>) {
+        let mut tasks = self.tasks.lock().unwrap();
+        tasks.push(task)
+    }
+
+    pub fn clear_task(&self) {
+        let mut tasks = self.tasks.lock().unwrap();
+        tasks.clear()
+    }
+
+    pub async fn wait_task_finish(&self) -> Result<(), RvError> {
+        let mut tasks = self.tasks.lock().unwrap();
+        for task in tasks.iter_mut() {
+            task.await?;
+        }
+
+        Ok(())
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -116,7 +116,7 @@ impl Core {
         self.self_ref = Some(Arc::clone(&core));
 
         // add auth_module
-        let auth_module = AuthModule::new(self);
+        let auth_module = AuthModule::new(self)?;
         self.module_manager.add_module(Arc::new(RwLock::new(Box::new(auth_module))))?;
 
         // add pki_module
@@ -218,7 +218,7 @@ impl Core {
         if let Some(module) = self.module_manager.get_module("auth") {
             let auth_mod = module.read()?;
             if let Some(auth_module) = auth_mod.as_ref().downcast_ref::<AuthModule>() {
-                let te = auth_module.token_store.root_token()?;
+                let te = auth_module.token_store.as_ref().unwrap().root_token()?;
                 init_result.root_token = te.id;
             } else {
                 log::error!("downcast auth module failed!");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -233,11 +233,6 @@ pub enum RvError {
         #[from]
         source: chrono::ParseError,
     },
-    #[error("Some delay_timer error happened, {:?}", .source)]
-    TaskError {
-        #[from]
-        source: delay_timer::error::TaskError,
-    },
     #[error("Some bcrypt error happened, {:?}", .source)]
     BcryptError {
         #[from]

--- a/src/logical/auth.rs
+++ b/src/logical/auth.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::lease::Lease;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Deref, DerefMut)]
+#[derive(Debug, Clone, Eq, Default, PartialEq, Serialize, Deserialize, Deref, DerefMut)]
 pub struct Auth {
     #[deref]
     #[deref_mut]

--- a/src/logical/auth.rs
+++ b/src/logical/auth.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use derive_more::{Deref, DerefMut};
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,9 @@ pub struct Auth {
     // Policies is the list of policies that the authenticated user is associated with.
     pub policies: Vec<String>,
 
+    // token_policies break down the list in policies to help determine where a policy was sourced
+    pub token_policies: Vec<String>,
+
     // Indicates that the default policy should not be added by core when creating a token.
     // The default policy will still be added if it's explicitly defined.
     pub no_default_policy: bool,
@@ -37,4 +40,12 @@ pub struct Auth {
     // Metadata is used to attach arbitrary string-type metadata to an authenticated user.
     // This metadata will be outputted into the audit log.
     pub metadata: HashMap<String, String>,
+
+    // period indicates that the token generated using this Auth object should never expire.
+    // The token should be renewed within the duration specified by this period.
+    pub period: Duration,
+
+    // explicit_max_ttl is the max TTL that constrains periodic tokens. For normal tokens,
+    // this value is constrained by the configured max ttl.
+    pub explicit_max_ttl: Duration,
 }

--- a/src/logical/connection.rs
+++ b/src/logical/connection.rs
@@ -1,6 +1,6 @@
 use openssl::x509::X509;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Connection {
     pub peer_addr: String,
     pub peer_tls_cert: Option<Vec<X509>>,

--- a/src/logical/lease.rs
+++ b/src/logical/lease.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime};
 use better_default::Default;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, Default, PartialEq, Serialize, Deserialize)]
 pub struct Lease {
     #[serde(rename = "lease")]
     pub ttl: Duration,

--- a/src/logical/lease.rs
+++ b/src/logical/lease.rs
@@ -1,7 +1,9 @@
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use better_default::Default;
 use serde::{Deserialize, Serialize};
+
+use crate::{errors::RvError, rv_error_string};
 
 #[derive(Debug, Clone, Eq, Default, PartialEq, Serialize, Deserialize)]
 pub struct Lease {
@@ -40,6 +42,268 @@ impl Lease {
             self.issue_time.unwrap() + self.ttl
         } else {
             SystemTime::now() + self.ttl
+        }
+    }
+}
+
+/// Calculates the TTL for a lease based on several parameters.
+///
+/// # Arguments
+/// - `max_lease_ttl`: The maximum allowed lease TTL by the system.
+/// - `default_lease_ttl`: The default TTL by the system.
+/// - `increment`: Incremental TTL specified by the user.
+/// - `period`: TTL period for certain lease types.
+/// - `backend_ttl`: TTL provided by the logical backend.
+/// - `backend_max_ttl`: Maximum TTL set by the logical backend.
+/// - `explicit_max_ttl`: Explicit maximum TTL set by the user.
+/// - `start_time`: The time when the lease was started.
+///
+/// # Returns
+/// `Result<Duration, RvError>` - The calculated TTL on success, or an error on failure.
+///
+/// This function calculates the effective TTL by considering various inputs
+/// and constraints, ensuring that the resulting TTL does not exceed allowed limits.
+pub fn calculate_ttl(
+    max_lease_ttl: Duration,
+    default_lease_ttl: Duration,
+    increment: Duration,
+    period: Duration,
+    backend_ttl: Duration,
+    backend_max_ttl: Duration,
+    explicit_max_ttl: Duration,
+    start_time: SystemTime,
+) -> Result<Duration, RvError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs()) // Truncate to second
+        .unwrap_or(0);
+
+    let start_time = start_time
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs()) // Truncate to second
+        .unwrap_or(now);
+
+    let mut max_ttl = max_lease_ttl;
+    if backend_max_ttl > Duration::ZERO && backend_max_ttl < max_ttl {
+        max_ttl = backend_max_ttl;
+    }
+    if explicit_max_ttl > Duration::ZERO && explicit_max_ttl < max_ttl {
+        max_ttl = explicit_max_ttl;
+    }
+
+    // Should never happen, but guard anyways
+    if max_ttl <= Duration::ZERO {
+        return Err(rv_error_string!("max TTL must be greater than zero"));
+    }
+
+    let mut ttl;
+    let mut max_valid_time = Duration::ZERO;
+
+    if period > Duration::ZERO {
+        // Cap the period value to the sys max_ttl value
+        if period > max_ttl {
+            ttl = max_ttl;
+        } else {
+            ttl = period;
+        }
+
+        if explicit_max_ttl > Duration::ZERO {
+            max_valid_time = Duration::from_secs(start_time) + explicit_max_ttl;
+        }
+    } else {
+        if increment > Duration::ZERO {
+            ttl = increment;
+        } else if backend_ttl > Duration::ZERO {
+            ttl = backend_ttl;
+        } else {
+            ttl = default_lease_ttl;
+        }
+
+        max_valid_time = Duration::from_secs(start_time) + max_ttl;
+    }
+
+    if !max_valid_time.is_zero() {
+        let max_valid_ttl = max_valid_time - Duration::from_secs(now);
+        if max_valid_ttl <= Duration::ZERO {
+            return Err(rv_error_string!("past the max TTL, cannot renew"));
+        }
+
+        if max_valid_ttl < ttl {
+            ttl = max_valid_ttl;
+        }
+    }
+
+    Ok(ttl)
+}
+
+#[cfg(test)]
+mod mod_lease_tests {
+    use super::*;
+
+    fn round_to_hour(time: SystemTime) -> SystemTime {
+        let since_epoch = time.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        let secs = since_epoch.as_secs();
+        let rounded_secs = (secs + 1800) / 3600 * 3600;
+        SystemTime::UNIX_EPOCH + Duration::from_secs(rounded_secs)
+    }
+
+    fn calculate_lease(now: SystemTime, ttl: Duration) -> Duration {
+        let new_time = now.checked_add(ttl).unwrap();
+        let rounded_new_time = round_to_hour(new_time);
+        rounded_new_time.duration_since(now).unwrap()
+    }
+
+    #[test]
+    fn test_calculate_ttl() {
+        struct Case(&'static str, Duration, Duration, Duration, Duration, Duration, Duration, Duration, Duration);
+
+        let cases = [
+            Case(
+                "valid request, good bounds, increment is preferred",
+                Duration::from_secs(30 * 60 * 60), // 30h
+                Duration::from_secs(5 * 60 * 60),  // 5h
+                Duration::from_secs(1 * 60 * 60),  // 1h
+                Duration::ZERO,
+                Duration::from_secs(30 * 60 * 60), // 30h
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(1 * 60 * 60), //1h
+            ),
+            Case(
+                "valid request, zero backend default, uses increment",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::from_secs(1 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(1 * 60 * 60),
+            ),
+            Case(
+                "lease increment is zero, uses backend default",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(30 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(30 * 60 * 60),
+            ),
+            Case(
+                "lease increment and default are zero, uses systemview",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(5 * 60 * 60),
+            ),
+            Case(
+                "backend max and associated request are too long",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(40 * 60 * 60),
+                Duration::from_secs(45 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(30 * 60 * 60),
+            ),
+            Case(
+                "all request values are larger than the system view, so the system view limits",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::from_secs(40 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(40 * 60 * 60),
+                Duration::from_secs(50 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(30 * 60 * 60),
+            ),
+            Case(
+                "request within backend max",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::from_secs(4 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(9 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(4 * 60 * 60),
+            ),
+            Case(
+                "request outside backend max",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(9 * 60 * 60),
+                Duration::from_secs(4 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(4 * 60 * 60),
+            ),
+            Case(
+                "lease increment too large",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::from_secs(40 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(30 * 60 * 60),
+            ),
+            Case(
+                "periodic, good request, period is preferred",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::from_secs(3 * 60 * 60),
+                Duration::from_secs(1 * 60 * 60),
+                Duration::from_secs(4 * 60 * 60),
+                Duration::from_secs(2 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(1 * 60 * 60),
+            ),
+            Case(
+                "period too large, explicit max ttl is preferred",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(2 * 60 * 60),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(1 * 60 * 60),
+                Duration::from_secs(1 * 60 * 60),
+            ),
+            Case(
+                "period too large, capped by backend max",
+                Duration::from_secs(30 * 60 * 60),
+                Duration::from_secs(5 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(2 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(1 * 60 * 60),
+                Duration::ZERO,
+                Duration::from_secs(1 * 60 * 60),
+            ),
+        ];
+
+        for case in cases.iter() {
+            let now = round_to_hour(SystemTime::now());
+            let ttl = calculate_ttl(case.1, case.2, case.3, case.4, case.5, case.6, case.7, SystemTime::now());
+            if ttl.is_err() {
+                println!("bad case: {}", case.0);
+            }
+            assert!(ttl.is_ok());
+            let lease = calculate_lease(now, ttl.unwrap());
+            if lease != case.8 {
+                println!("bad case: {}, lease: {:?}", case.0, lease);
+            }
+            assert_eq!(lease, case.8);
         }
     }
 }

--- a/src/logical/lease.rs
+++ b/src/logical/lease.rs
@@ -38,10 +38,10 @@ impl Lease {
     }
 
     pub fn expiration_time(&self) -> SystemTime {
-        if self.issue_time.is_some() {
-            self.issue_time.unwrap() + self.ttl
-        } else {
+        if self.enabled() {
             SystemTime::now() + self.ttl
+        } else {
+            SystemTime::UNIX_EPOCH
         }
     }
 }

--- a/src/logical/request.rs
+++ b/src/logical/request.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use better_default::Default;
 use serde_json::{Map, Value};
-use tokio::task::JoinHandle;
 
 use super::{Operation, Path};
 use crate::{
@@ -13,7 +12,7 @@ use crate::{
     storage::{Storage, StorageEntry},
 };
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Request {
     pub id: String,
     pub name: String,
@@ -29,7 +28,6 @@ pub struct Request {
     pub connection: Option<Connection>,
     pub secret: Option<SecretData>,
     pub auth: Option<Auth>,
-    pub tasks: Vec<JoinHandle<()>>,
     pub handler: Option<Arc<dyn Handler>>,
     #[default(HandlePhase::PreRoute)]
     pub handle_phase: HandlePhase,
@@ -214,21 +212,5 @@ impl Request {
         }
 
         self.storage.as_ref().unwrap().delete(key)
-    }
-
-    pub fn add_task(&mut self, task: JoinHandle<()>) {
-        self.tasks.push(task);
-    }
-
-    pub fn clear_task(&mut self) {
-        self.tasks.clear();
-    }
-
-    pub async fn wait_task_finish(&mut self) -> Result<(), RvError> {
-        for task in &mut self.tasks {
-            task.await?;
-        }
-
-        Ok(())
     }
 }

--- a/src/logical/request.rs
+++ b/src/logical/request.rs
@@ -99,7 +99,7 @@ impl Request {
     }
 
     pub fn get_data(&self, key: &str) -> Result<Value, RvError> {
-        if self.storage.is_none() || self.match_path.is_none() {
+        if self.match_path.is_none() {
             return Err(RvError::ErrRequestNotReady);
         }
 
@@ -111,7 +111,7 @@ impl Request {
     }
 
     pub fn get_data_or_default(&self, key: &str) -> Result<Value, RvError> {
-        if self.storage.is_none() || self.match_path.is_none() {
+        if self.match_path.is_none() {
             return Err(RvError::ErrRequestNotReady);
         }
 
@@ -123,7 +123,7 @@ impl Request {
     }
 
     pub fn get_data_or_next(&self, keys: &[&str]) -> Result<Value, RvError> {
-        if self.storage.is_none() || self.match_path.is_none() {
+        if self.match_path.is_none() {
             return Err(RvError::ErrRequestNotReady);
         }
 
@@ -158,6 +158,9 @@ impl Request {
     }
 
     pub fn get_field_default_or_zero(&self, key: &str) -> Result<Value, RvError> {
+        if self.match_path.is_none() {
+            return Err(RvError::ErrRequestNotReady);
+        }
         let field = self.match_path.as_ref().unwrap().get_field(key).ok_or(RvError::ErrRequestNoDataField)?;
         field.get_default()
     }

--- a/src/logical/response.rs
+++ b/src/logical/response.rs
@@ -16,7 +16,7 @@ lazy_static! {
     static ref HTTP_STATUS_CODE: &'static str = "http_status_code";
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct Response {
     #[serde(default)]
     pub request_id: String,

--- a/src/logical/secret.rs
+++ b/src/logical/secret.rs
@@ -9,7 +9,7 @@ use crate::errors::RvError;
 
 type SecretOperationHandler = dyn Fn(&dyn Backend, &mut Request) -> Result<Option<Response>, RvError> + Send + Sync;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Deref, DerefMut)]
+#[derive(Debug, Clone, Eq, Default, PartialEq, Serialize, Deserialize, Deref, DerefMut)]
 pub struct SecretData {
     #[deref]
     #[deref_mut]

--- a/src/logical/secret.rs
+++ b/src/logical/secret.rs
@@ -16,7 +16,7 @@ pub struct SecretData {
     #[serde(flatten)]
     pub lease: Lease,
     pub lease_id: String,
-    #[serde(skip)]
+    #[serde(default)]
     pub internal_data: Map<String, Value>,
 }
 

--- a/src/modules/auth/token_store.rs
+++ b/src/modules/auth/token_store.rs
@@ -6,7 +6,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock, Weak},
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
@@ -27,13 +27,19 @@ use crate::{
     errors::RvError,
     handler::{AuthHandler, HandlePhase, Handler},
     logical::{
-        Auth, Backend, Field, FieldType, Lease, LogicalBackend, Operation, Path, PathOperation, Request, Response,
+        lease::calculate_ttl, Auth, Backend, Field, FieldType, Lease, LogicalBackend, Operation, Path, PathOperation,
+        Request, Response,
     },
     new_fields, new_fields_internal, new_logical_backend, new_logical_backend_internal, new_path, new_path_internal,
     router::Router,
-    rv_error_response,
+    rv_error_response, rv_error_string,
     storage::{Storage, StorageEntry},
-    utils::{generate_uuid, is_str_subset, policy::sanitize_policies, sha1},
+    utils::{
+        deserialize_duration, deserialize_system_time, generate_uuid, is_str_subset,
+        policy::sanitize_policies,
+        serialize_duration, serialize_system_time, sha1,
+        token_util::{DEFAULT_LEASE_TTL, MAX_LEASE_TTL},
+    },
 };
 
 const TOKEN_LOOKUP_PREFIX: &str = "id/";
@@ -69,6 +75,10 @@ struct TokenReqData {
     num_uses: u32,
     #[serde(default)]
     renewable: bool,
+    #[serde(default, deserialize_with = "deserialize_duration")]
+    period: Duration,
+    #[serde(default, deserialize_with = "deserialize_duration")]
+    explicit_max_ttl: Duration,
 }
 
 /// Data structure representing a stored token entry.
@@ -83,6 +93,13 @@ pub struct TokenEntry {
     pub display_name: String,
     pub num_uses: u32,
     pub ttl: u64,
+    #[default(SystemTime::now())]
+    #[serde(serialize_with = "serialize_system_time", deserialize_with = "deserialize_system_time")]
+    pub creation_time: SystemTime,
+    #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
+    pub period: Duration,
+    #[serde(serialize_with = "serialize_duration", deserialize_with = "deserialize_duration")]
+    pub explicit_max_ttl: Duration,
 }
 
 /// Manages the storage and handling of tokens.
@@ -151,11 +168,35 @@ impl TokenStore {
         let ts_inner_arc4 = self.self_ptr.upgrade().unwrap().clone();
         let ts_inner_arc5 = self.self_ptr.upgrade().unwrap().clone();
         let ts_inner_arc6 = self.self_ptr.upgrade().unwrap().clone();
+        let ts_inner_arc7 = self.self_ptr.upgrade().unwrap().clone();
 
         let backend = new_logical_backend!({
             paths: [
                 {
                     pattern: "create*",
+                    fields: {
+                        "num_uses": {
+                            field_type: FieldType::Int,
+                            description: "Max number of uses for this token"
+                        },
+                        "period": {
+                            field_type: FieldType::Str,
+                            description: "Renew period"
+                        },
+                        "ttl": {
+                            field_type: FieldType::DurationSecond,
+                            description: "Time to live for this token"
+                        },
+                        "renewable": {
+                            field_type: FieldType::Bool,
+                            default: true,
+                            description: "Allow token to be renewed past its initial TTL up to system/mount maximum TTL"
+                        },
+                        "policies": {
+                            field_type: FieldType::Array,
+                            description: "List of policies for the token"
+                        }
+                    },
                     operations: [
                         {op: Operation::Write, handler: ts_inner_arc1.handle_create}
                     ],
@@ -231,6 +272,7 @@ impl TokenStore {
                     help: "This endpoint will renew the token and prevent expiration."
                 }
             ],
+            auth_renew_handler: ts_inner_arc7.auth_renew,
             root_paths: ["revoke-orphan/*"],
             help: AUTH_TOKEN_HELP,
         });
@@ -286,10 +328,10 @@ impl TokenStore {
             view.put(&entry)?;
         }
 
-        let path = format!("{}{}", TOKEN_LOOKUP_PREFIX, salted_id);
-        let entry = StorageEntry { key: path, value: value.as_bytes().to_vec() };
-
-        view.put(&entry)
+        view.put(&StorageEntry {
+            key: format!("{}{}", TOKEN_LOOKUP_PREFIX, salted_id),
+            value: value.as_bytes().to_vec(),
+        })
     }
 
     /// Uses the token and decrements its use count.
@@ -401,7 +443,7 @@ impl TokenStore {
                 view.delete(&path)?;
             }
             //Revoke all secrets under this token
-            self.expiration.revoke_by_token(&entry.id)?;
+            self.expiration.revoke_by_token(&entry)?;
         }
 
         Ok(())
@@ -517,6 +559,27 @@ impl TokenStore {
             te.ttl = dur.as_secs();
         }
 
+        te.period = data.period;
+        te.explicit_max_ttl = data.explicit_max_ttl;
+
+        if te.period.as_secs() > 0 || te.ttl > 0 || (te.ttl == 0 && !te.policies.contains(&"root".to_string())) {
+            te.ttl = calculate_ttl(
+                MAX_LEASE_TTL,
+                DEFAULT_LEASE_TTL,
+                Duration::ZERO,
+                te.period,
+                Duration::from_secs(te.ttl),
+                Duration::ZERO,
+                te.explicit_max_ttl,
+                te.creation_time,
+            )?
+            .as_secs();
+        }
+
+        if te.ttl == 0 && te.explicit_max_ttl.as_secs() > 0 {
+            te.ttl = te.explicit_max_ttl.as_secs();
+        }
+
         if data.no_parent {
             // TODO: Only allow an orphan token if the client has sudo policy
             te.parent.clear();
@@ -536,6 +599,8 @@ impl TokenStore {
             client_token: te.id.clone(),
             display_name: te.display_name.clone(),
             policies: te.policies.clone(),
+            period: te.period,
+            explicit_max_ttl: te.explicit_max_ttl,
             metadata: te.meta.clone(),
             ..Default::default()
         };
@@ -603,18 +668,25 @@ impl TokenStore {
 
         let meta = serde_json::to_value(&te.meta)?;
 
-        let data = serde_json::json!({
+        let mut data = serde_json::json!({
             "id": te.id.clone(),
             "policies": te.policies.clone(),
             "path": te.path.clone(),
             "meta": meta,
             "display_name": te.display_name.clone(),
             "num_uses": te.num_uses,
-            "ttl": te.ttl,
+            "ttl": 0,
+            "creation_time": te.creation_time.duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0),
+            "creation_ttl": te.ttl,
+            "explicit_max_ttl": te.explicit_max_ttl.as_secs(),
         })
         .as_object()
         .unwrap()
         .clone();
+
+        if te.period.as_secs() > 0 {
+            data.insert("period".to_string(), json!(te.period.as_secs()));
+        }
 
         Ok(Some(Response::data_response(Some(data))))
     }
@@ -625,20 +697,27 @@ impl TokenStore {
             return Err(RvError::ErrRequestInvalid);
         }
 
-        let te = self.lookup(&id)?;
-        if te.is_none() {
-            return Err(RvError::ErrRequestInvalid);
-        }
-        let te = te.unwrap();
+        let te = self.lookup(&id)?.ok_or(RvError::ErrRequestInvalid)?;
 
         let increment_raw: i32 = serde_json::from_value(req.get_data("increment")?)?;
         let increment = Duration::from_secs(increment_raw as u64);
 
-        let auth = self.expiration.renew_token(&te.path, &te.id, increment)?;
+        self.expiration.renew_token(req, &te, increment)
+    }
 
-        let resp = Response { auth, ..Response::default() };
+    pub fn auth_renew(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        if req.auth.is_none() {
+            return Err(rv_error_string!("request auth is nil"));
+        }
 
-        Ok(Some(resp))
+        let id = &req.auth.as_ref().unwrap().client_token;
+        let te = self.lookup(id)?.ok_or(rv_error_string!("no token entry found during lookup"))?;
+
+        let auth = req.auth.as_mut().unwrap();
+        auth.period = te.period;
+        auth.explicit_max_ttl = te.explicit_max_ttl;
+
+        Ok(Some(Response { auth: Some(auth.clone()), ..Default::default() }))
     }
 }
 
@@ -760,7 +839,21 @@ impl Handler for TokenStore {
                 auth.ttl = MAX_LEASE_DURATION_SECS;
             }
 
-            sanitize_policies(&mut auth.policies, !auth.no_default_policy);
+            let token_ttl = calculate_ttl(
+                MAX_LEASE_TTL,
+                DEFAULT_LEASE_TTL,
+                Duration::ZERO,
+                auth.period,
+                auth.ttl,
+                auth.max_ttl,
+                auth.explicit_max_ttl,
+                SystemTime::now(),
+            )?;
+
+            auth.token_policies = auth.policies.clone();
+            sanitize_policies(&mut auth.token_policies, !auth.no_default_policy);
+
+            let all_policies = auth.token_policies.clone();
 
             if auth.policies.contains(&"root".to_string()) {
                 return Err(rv_error_response!("auth methods cannot create root tokens"));
@@ -770,15 +863,21 @@ impl Handler for TokenStore {
                 path: req.path.clone(),
                 meta: auth.metadata.clone(),
                 display_name: auth.display_name.clone(),
-                ttl: auth.ttl.as_secs(),
+                ttl: token_ttl.as_secs(),
+                policies: auth.token_policies.clone(),
+                explicit_max_ttl: auth.explicit_max_ttl,
+                period: auth.period,
                 ..Default::default()
             };
 
             self.create(&mut te)?;
 
             auth.client_token = te.id.clone();
+            auth.ttl = Duration::from_secs(te.ttl);
 
-            self.expiration.register_auth(&req.path, auth)?;
+            self.expiration.register_auth(&te, auth)?;
+
+            auth.policies = all_policies;
         }
 
         Ok(())
@@ -794,7 +893,7 @@ mod mod_token_store_tests {
         test_utils::test_rusty_vault_init,
     };
 
-    macro_rules! new_token_store {
+    macro_rules! mock_token_store {
         () => {{
             let name = format!("{}_{}", file!(), line!()).replace("/", "_").replace("\\", "_").replace(".", "_");
             println!("test_rusty_vault_init, name: {}", name);
@@ -841,7 +940,7 @@ mod mod_token_store_tests {
 
     #[test]
     fn test_token_create_and_lookup() {
-        let token_store = new_token_store!();
+        let token_store = mock_token_store!();
 
         let mut entry = TokenEntry {
             policies: vec!["default".to_string()],
@@ -861,7 +960,7 @@ mod mod_token_store_tests {
 
     #[test]
     fn test_token_revoke() {
-        let token_store = new_token_store!();
+        let token_store = mock_token_store!();
 
         let mut entry = TokenEntry {
             policies: vec!["default".to_string()],
@@ -880,7 +979,7 @@ mod mod_token_store_tests {
 
     #[test]
     fn test_token_revoke_tree() {
-        let token_store = new_token_store!();
+        let token_store = mock_token_store!();
 
         let mut parent_entry = TokenEntry {
             policies: vec!["default".to_string()],
@@ -909,7 +1008,7 @@ mod mod_token_store_tests {
 
     #[test]
     fn test_token_handle_create_request() {
-        let token_store = new_token_store!();
+        let token_store = mock_token_store!();
         let mock_backend = MockBackend(());
 
         let mut entry = TokenEntry {

--- a/src/modules/credential/approle/mod.rs
+++ b/src/modules/credential/approle/mod.rs
@@ -111,7 +111,7 @@ impl AppRoleBackend {
 
         let mut backend = new_logical_backend!({
             unauth_paths: ["login"],
-            auth_renew_handler: approle_backend_ref.renew_path_login,
+            auth_renew_handler: approle_backend_ref.login_renew,
             help: APPROLE_BACKEND_HELP,
         });
 
@@ -137,10 +137,6 @@ impl AppRoleBackendInner {
             secret_id_accessor_locks: Locks::new(),
             tidy_secret_id_cas_guard: AtomicU32::new(0),
         }
-    }
-
-    pub fn renew_path_login(&self, _backend: &dyn Backend, _req: &mut Request) -> Result<Option<Response>, RvError> {
-        Ok(None)
     }
 }
 

--- a/src/modules/credential/approle/path_tidy_secret_id.rs
+++ b/src/modules/credential/approle/path_tidy_secret_id.rs
@@ -228,7 +228,7 @@ impl AppRoleBackendInner {
             path_inner.tidy_secret_id_routine(storage).await;
         });
 
-        req.add_task(task);
+        req.ctx.add_task(task);
 
         resp.set_request_id(&req.id);
         resp.add_warning(
@@ -335,7 +335,7 @@ mod test {
         req.path = "tidy/secret-id".to_string();
         let _resp = mock_backend.handle_request(&mut req);
 
-        assert!(req.wait_task_finish().await.is_ok());
+        assert!(req.ctx.wait_task_finish().await.is_ok());
 
         let accessor = req.storage_list("accessor/");
         assert!(accessor.is_ok());
@@ -429,7 +429,7 @@ mod test {
             thread::sleep(Duration::from_micros(10));
         }
 
-        assert!(req.wait_task_finish().await.is_ok());
+        assert!(req.ctx.wait_task_finish().await.is_ok());
 
         // Wait for tidy to finish
         while approle_module.tidy_secret_id_cas_guard.load(Ordering::SeqCst) != 0 {
@@ -437,14 +437,14 @@ mod test {
         }
 
         // Run tidy again
-        req.clear_task();
+        req.ctx.clear_task();
 
         req.operation = Operation::Write;
         req.path = "tidy/secret-id".to_string();
         let resp = mock_backend.handle_request(&mut req);
         assert!(resp.is_ok());
 
-        assert!(req.wait_task_finish().await.is_ok());
+        assert!(req.ctx.wait_task_finish().await.is_ok());
 
 
         let num = count.lock().unwrap();

--- a/src/modules/credential/cert/mod.rs
+++ b/src/modules/credential/cert/mod.rs
@@ -153,10 +153,8 @@ mod test {
 
     use super::*;
     use crate::{
-        test_utils::{
-            TestHttpServer, TestTlsClientAuth, new_test_cert, new_test_cert_ext, new_test_crl,
-        },
-        modules::auth::expiration::MAX_LEASE_DURATION_SECS,
+        modules::auth::expiration::DEFAULT_LEASE_DURATION_SECS,
+        test_utils::{new_test_cert, new_test_cert_ext, new_test_crl, TestHttpServer, TestTlsClientAuth},
     };
 
     #[derive(Default)]
@@ -588,8 +586,9 @@ mod test {
 
         test_http_server.test_write_cert_no_lease("web", &ca_cert, "foo");
 
-        let (_, resp) = test_http_server.test_login(&test_http_server.ca_cert_pem, &client_cert, &client_key, None).unwrap();
-        assert_eq!(resp["auth"]["lease_duration"], MAX_LEASE_DURATION_SECS.as_secs());
+        let (_, resp) =
+            test_http_server.test_login(&test_http_server.ca_cert_pem, &client_cert, &client_key, None).unwrap();
+        assert_eq!(resp["auth"]["lease_duration"], DEFAULT_LEASE_DURATION_SECS.as_secs());
         assert_eq!(resp["auth"]["policies"], json!(["default", "foo"]));
 
         test_http_server.test_write_crl(&ca_cert, &ca_cert, &ca_key);
@@ -600,8 +599,9 @@ mod test {
 
         test_http_server.test_delete_crl();
 
-        let (_, resp) = test_http_server.test_login(&test_http_server.ca_cert_pem, &client_cert, &client_key, None).unwrap();
-        assert_eq!(resp["auth"]["lease_duration"], MAX_LEASE_DURATION_SECS.as_secs());
+        let (_, resp) =
+            test_http_server.test_login(&test_http_server.ca_cert_pem, &client_cert, &client_key, None).unwrap();
+        assert_eq!(resp["auth"]["lease_duration"], DEFAULT_LEASE_DURATION_SECS.as_secs());
         assert_eq!(resp["auth"]["policies"], json!(["default", "foo"]));
     }
 

--- a/src/modules/credential/cert/mod.rs
+++ b/src/modules/credential/cert/mod.rs
@@ -73,7 +73,7 @@ impl CertBackend {
 
         let mut backend = new_logical_backend!({
             unauth_paths: ["login"],
-            auth_renew_handler: cert_backend_ref.renew_path_login,
+            auth_renew_handler: cert_backend_ref.login_renew,
             help: CERT_BACKEND_HELP,
         });
 
@@ -85,12 +85,6 @@ impl CertBackend {
         backend.paths.push(Arc::new(self.login_path()));
 
         backend
-    }
-}
-
-impl CertBackendInner {
-    pub fn renew_path_login(&self, _backend: &dyn Backend, _req: &mut Request) -> Result<Option<Response>, RvError> {
-        Ok(None)
     }
 }
 

--- a/src/modules/credential/cert/path_login.rs
+++ b/src/modules/credential/cert/path_login.rs
@@ -26,7 +26,7 @@ use crate::{
     context::Context,
     errors::RvError,
     logical::{Auth, Backend, Field, FieldType, Operation, Path, PathOperation, Request, Response},
-    new_fields, new_fields_internal, new_path, new_path_internal, rv_error_response, rv_error_response_status,
+    new_fields, new_fields_internal, new_path, new_path_internal, rv_error_response, rv_error_string,
     utils::{
         self,
         cert::{
@@ -34,6 +34,7 @@ use crate::{
         },
         ocsp::{self, OcspConfig},
         cidr::remote_addr_is_ok,
+        policy::equivalent_policies,
         sock_addr::SockAddr,
     },
 };
@@ -141,9 +142,74 @@ impl CertBackendInner {
         Ok(Some(resp))
     }
 
-    pub fn login_renew(&self, _backend: &dyn Backend, _req: &mut Request) -> Result<Option<Response>, RvError> {
-        //TODO
-        return Err(rv_error_response_status!(502, "TODO"));
+    pub fn login_renew(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        let config = self.get_config(req)?.ok_or(RvError::ErrCredentailNotConfig)?;
+
+        if req.connection.is_none() {
+            return Err(rv_error_response!("tls connection required"));
+        }
+
+        if req.auth.is_none() {
+            return Err(rv_error_response!("invalid request"));
+        }
+        let mut auth = req.auth.clone().unwrap();
+
+        if !config.disable_binding {
+            let subject_key_id = auth
+                .metadata
+                .get("subject_key_id")
+                .ok_or(rv_error_response!("invalid request, not found subject_key_id"))?;
+            let authority_key_id = auth
+                .metadata
+                .get("authority_key_id")
+                .ok_or(rv_error_response!("invalid request, not found authority_key_id"))?;
+
+            let _matched = self.verify_credentials(req)?;
+
+            let conn = req.connection.as_ref().ok_or(RvError::ErrRequestNotReady)?;
+
+            let client_cert = conn
+                .peer_tls_cert
+                .as_ref()
+                .filter(|cert| !cert.is_empty())
+                .and_then(|cert| cert.first())
+                .ok_or(rv_error_response!("no client certificate found"))?;
+
+            let cert_subject_key_id = client_cert.subject_key_id().map(|asn1_ref| asn1_ref.as_slice()).unwrap_or(b"");
+            let cert_authority_key_id =
+                client_cert.authority_key_id().map(|asn1_ref| asn1_ref.as_slice()).unwrap_or(b"");
+
+            let skid_hex = utils::hex_encode_with_colon(cert_subject_key_id);
+            let akid_hex = utils::hex_encode_with_colon(cert_authority_key_id);
+
+            // Certificate should not only match a registered certificate policy.
+            // Also, the identity of the certificate presented should match the identity of the certificate used during login
+            if *subject_key_id != skid_hex && *authority_key_id != akid_hex {
+                return Err(rv_error_response!(
+                    "client identity during renewal not matching client identity used during login"
+                ));
+            }
+        }
+
+        let cert_name =
+            auth.metadata.get("cert_name").ok_or(rv_error_response!("invalid request, not found cert_name"))?;
+
+        let cert = self.get_cert(req, cert_name.as_str())?;
+        if cert.is_none() {
+            return Ok(None);
+        }
+
+        let cert = cert.unwrap();
+
+        if !equivalent_policies(&cert.policies, &auth.policies) {
+            return Err(rv_error_string!("policies have changed, not renewing"));
+        }
+
+        auth.period = cert.token_period;
+        auth.ttl = cert.token_ttl;
+        auth.max_ttl = cert.token_max_ttl;
+
+        Ok(Some(Response { auth: Some(auth), ..Response::default() }))
     }
 
     fn verify_credentials(&self, req: &Request) -> Result<ParsedCert, RvError> {

--- a/src/modules/credential/userpass/mod.rs
+++ b/src/modules/credential/userpass/mod.rs
@@ -49,7 +49,7 @@ impl UserPassBackend {
 
         let mut backend = new_logical_backend!({
             unauth_paths: ["login/*"],
-            auth_renew_handler: userpass_backend_ref.renew_path_login,
+            auth_renew_handler: userpass_backend_ref.login_renew,
             help: USERPASS_BACKEND_HELP,
         });
 
@@ -59,12 +59,6 @@ impl UserPassBackend {
         backend.paths.push(Arc::new(self.login_path()));
 
         backend
-    }
-}
-
-impl UserPassBackendInner {
-    pub fn renew_path_login(&self, _backend: &dyn Backend, _req: &mut Request) -> Result<Option<Response>, RvError> {
-        Ok(None)
     }
 }
 

--- a/src/modules/credential/userpass/mod.rs
+++ b/src/modules/credential/userpass/mod.rs
@@ -207,8 +207,8 @@ mod test {
         let resp = test_login(&core, "pass", "test", "123qwe!@#", true).await;
         let login_auth = resp.unwrap().unwrap().auth.unwrap();
         let test_client_token = login_auth.client_token.clone();
-        let resp = test_read_api(&core, &test_client_token, "sys/mounts", true).await;
-        println!("test mounts resp: {:?}", resp);
+        let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", true).await;
+        println!("read auth/token/lookup-self resp: {:?}", resp);
         assert!(resp.unwrap().is_some());
 
         test_delete_user(&core, &root_token, "test").await;
@@ -228,7 +228,8 @@ mod test {
         std::thread::sleep(Duration::from_secs(7));
         let test_client_token = login_auth.client_token.clone();
         let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", false).await;
-        println!("test lookup-self resp: {:?}", resp);
+        println!("read auth/token/lookup-self resp: {:?}", resp);
+        assert_eq!(resp.unwrap_err(), RvError::ErrPermissionDenied);
 
         // mount userpass auth to path: auth/testpass
         test_mount_auth_api(&core, &root_token, "userpass", "testpass").await;
@@ -238,7 +239,7 @@ mod test {
         let test_client_token = login_auth.client_token.clone();
         println!("test_client_token: {}", test_client_token);
         let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", true).await;
-        println!("test lookup-self resp: {:?}", resp);
+        println!("read auth/token/lookup-self resp: {:?}", resp);
         assert!(resp.unwrap().is_some());
     }
 }

--- a/src/modules/credential/userpass/mod.rs
+++ b/src/modules/credential/userpass/mod.rs
@@ -227,8 +227,8 @@ mod test {
         println!("wait 7s");
         std::thread::sleep(Duration::from_secs(7));
         let test_client_token = login_auth.client_token.clone();
-        let resp = test_read_api(&core, &test_client_token, "sys/mounts", false).await;
-        println!("test mounts resp: {:?}", resp);
+        let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", false).await;
+        println!("test lookup-self resp: {:?}", resp);
 
         // mount userpass auth to path: auth/testpass
         test_mount_auth_api(&core, &root_token, "userpass", "testpass").await;
@@ -237,8 +237,8 @@ mod test {
         let login_auth = resp.unwrap().unwrap().auth.unwrap();
         let test_client_token = login_auth.client_token.clone();
         println!("test_client_token: {}", test_client_token);
-        let resp = test_read_api(&core, &test_client_token, "sys/mounts", true).await;
-        println!("test mounts resp: {:?}", resp);
+        let resp = test_read_api(&core, &test_client_token, "auth/token/lookup-self", true).await;
+        println!("test lookup-self resp: {:?}", resp);
         assert!(resp.unwrap().is_some());
     }
 }

--- a/src/modules/credential/userpass/path_login.rs
+++ b/src/modules/credential/userpass/path_login.rs
@@ -5,7 +5,8 @@ use crate::{
     context::Context,
     errors::RvError,
     logical::{Auth, Backend, Field, FieldType, Lease, Operation, Path, PathOperation, Request, Response},
-    new_fields, new_fields_internal, new_path, new_path_internal,
+    new_fields, new_fields_internal, new_path, new_path_internal, rv_error_string,
+    utils::policy::equivalent_policies,
 };
 
 impl UserPassBackend {
@@ -78,5 +79,34 @@ impl UserPassBackendInner {
         let resp = Response { auth: Some(auth), ..Response::default() };
 
         Ok(Some(resp))
+    }
+
+    pub fn login_renew(&self, _backend: &dyn Backend, req: &mut Request) -> Result<Option<Response>, RvError> {
+        if req.auth.is_none() {
+            return Err(rv_error_string!("invalid request"));
+        }
+        let mut auth = req.auth.clone().unwrap();
+        let username = auth.metadata.get("username");
+        if username.is_none() {
+            return Ok(None);
+        }
+        let username = username.unwrap();
+
+        let user = self.get_user(req, username.as_str())?;
+        if user.is_none() {
+            return Ok(None);
+        }
+
+        let user = user.unwrap();
+
+        if !equivalent_policies(&user.policies, &auth.policies) {
+            return Err(rv_error_string!("policies have changed, not renewing"));
+        }
+
+        auth.period = user.token_period;
+        auth.ttl = user.token_ttl;
+        auth.max_ttl = user.token_max_ttl;
+
+        Ok(Some(Response { auth: Some(auth), ..Response::default() }))
     }
 }

--- a/src/modules/pki/mod.rs
+++ b/src/modules/pki/mod.rs
@@ -277,7 +277,9 @@ mod test {
         .clone();
 
         // issue cert
-        let resp = test_write_api(core, token, format!("{}issue/{}", path, role_name).as_str(), true, Some(issue_data)).await;
+        let now_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let resp =
+            test_write_api(core, token, format!("{}issue/{}", path, role_name).as_str(), true, Some(issue_data)).await;
         assert!(resp.is_ok());
         let resp_body = resp.unwrap();
         assert!(resp_body.is_some());
@@ -306,12 +308,12 @@ mod test {
         let ttl_compare = cert.not_after().compare(&expiration_time);
         assert!(ttl_compare.is_ok());
         assert_eq!(ttl_compare.unwrap(), std::cmp::Ordering::Equal);
-        let now_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
         let expiration_ttl = cert_data["expiration"].as_u64().unwrap();
         let ttl = expiration_ttl - now_timestamp;
         let expect_ttl = 10 * 24 * 60 * 60;
+        println!("ttl: {}, expect_ttl: {}", ttl, expect_ttl);
         assert!(ttl <= expect_ttl);
-        assert!((ttl + 10) > expect_ttl);
+        assert!((ttl + 10) >= expect_ttl);
 
         let authority_key_id = cert.authority_key_id();
         assert!(authority_key_id.is_some());

--- a/src/storage/barrier_view.rs
+++ b/src/storage/barrier_view.rs
@@ -63,6 +63,7 @@ impl BarrierView {
                 }
             }
         }
+        keys.sort();
         Ok(keys)
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -44,8 +44,9 @@ use ureq::AgentBuilder;
 
 use crate::{
     core::{Core, InitResult, SealConfig},
-    errors::RvError, http,
-    logical::{Operation, Request, Response},
+    errors::RvError,
+    http,
+    logical::{self, Operation, Request, Response},
     metrics::{manager::MetricsManager, middleware::metrics_midleware, system_metrics::SystemMetrics},
     rv_error_response, rv_error_string,
     storage::{self, Backend}, utils::cert::Certificate
@@ -1221,4 +1222,95 @@ pub fn get_project_binary_path() -> String {
     binary_path.push(bin_name);
 
     binary_path.into_os_string().into_string().unwrap_or_default()
+}
+
+type BackendTestRequestHandler = dyn Fn(&mut Request) -> Result<Option<Response>, RvError> + Send + Sync;
+
+#[derive(Default)]
+pub struct NoopBackend {
+    pub root: Vec<String>,
+    pub login: Vec<String>,
+    pub paths: RwLock<Vec<String>>,
+    pub requests: RwLock<Vec<Request>>,
+    pub response: Option<Response>,
+    pub request_handler: Option<Arc<BackendTestRequestHandler>>,
+    pub invalidations: Vec<String>,
+    pub default_lease_ttl: Duration,
+    pub max_lease_ttl: Duration,
+    pub rollback_errs: bool,
+}
+
+impl Clone for NoopBackend {
+    fn clone(&self) -> Self {
+        NoopBackend {
+            root: self.root.clone(),
+            login: self.login.clone(),
+            paths: RwLock::new(self.paths.read().unwrap().clone()),
+            requests: RwLock::new(self.requests.read().unwrap().clone()),
+            response: self.response.clone(),
+            request_handler: self.request_handler.clone(),
+            invalidations: self.invalidations.clone(),
+            default_lease_ttl: self.default_lease_ttl.clone(),
+            max_lease_ttl: self.max_lease_ttl.clone(),
+            rollback_errs: self.rollback_errs.clone(),
+        }
+    }
+}
+
+impl logical::Backend for NoopBackend {
+    fn handle_request(&self, req: &mut Request) -> Result<Option<Response>, RvError> {
+        if self.rollback_errs && req.operation == Operation::Rollback {
+            return Err(rv_error_string!("no-op backend rollback has erred out"));
+        }
+
+        let resp = self.request_handler.as_ref().map_or(Ok(None), |handler| handler(req))?;
+
+        let mut requests = self.requests.write()?;
+        requests.push(req.clone());
+
+        let mut path = self.paths.write()?;
+        path.push(req.path.clone());
+
+        if req.storage.is_none() {
+            return Err(rv_error_string!("missing view"));
+        }
+
+        if req.path == "panic" {
+            panic!("as you command");
+        }
+
+        if resp.is_some() {
+            return Ok(resp);
+        }
+
+        Ok(self.response.clone())
+    }
+
+    fn cleanup(&self) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn get_ctx(&self) -> Option<Arc<crate::context::Context>> {
+        None
+    }
+
+    fn get_root_paths(&self) -> Option<Arc<Vec<String>>> {
+        Some(Arc::new(self.root.clone()))
+    }
+
+    fn get_unauth_paths(&self) -> Option<Arc<Vec<String>>> {
+        Some(Arc::new(self.login.clone()))
+    }
+
+    fn init(&mut self) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn setup(&self, _key: &str) -> Result<(), RvError> {
+        Ok(())
+    }
+
+    fn secret(&self, _key: &str) -> Option<&Arc<logical::secret::Secret>> {
+        None
+    }
 }

--- a/src/utils/token_util.rs
+++ b/src/utils/token_util.rs
@@ -10,10 +10,10 @@ use crate::{
     utils::{deserialize_duration, serialize_duration, sock_addr::SockAddrMarshaler},
 };
 
-/*
-const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(365 * 24 * 60 * 60 as u64);
-const MAX_LEASE_TTL: Duration = Duration::from_secs(365 * 24 * 60 * 60 as u64);
-*/
+// 24h
+pub const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(24 * 60 * 60 as u64);
+// 30d
+pub const MAX_LEASE_TTL: Duration = Duration::from_secs(30 * 24 * 60 * 60 as u64);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenParams {


### PR DESCRIPTION
1. Each LeaseEntry used one thread before, consuming too many resources. Now using PriorityQueue, only one thread is needed.
2. Removed the dependency on delay_timer.
3. Optimize auth module data structure and code for clarity and conciseness.
4. Implemented the auth_renew interface for authentication modules such as auth, usepass, cert, and approle.
5. Fix bugs in the auth module and add test cases.