### PR TITLE
Add sync_handler feature for v0.2.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/website.yml"
       - ".github/workflows/deploy-website.yml"
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "v0.2" ]
     paths-ignore:
       - "docs/**"
       - ".github/workflows/website.yml"
@@ -35,6 +35,8 @@ jobs:
       run: ulimit -n 65535
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests with sync_handler features
+      run: cargo test --features sync_handler --verbose
     - name: debug with ssh tunnel
       if: ${{ failure() }}
       uses: wa5i/ssh-to-actions@main
@@ -77,6 +79,10 @@ jobs:
       run : |
         export LD_LIBRARY_PATH=${RUNNER_TEMP}/tongsuo/lib
         OPENSSL_DIR=${RUNNER_TEMP}/tongsuo RUSTFLAGS="-C link-args=-Wl,-rpath,${RUNNER_TEMP}/tongsuo/lib" cargo test --verbose --features crypto_adaptor_tongsuo --no-default-features
+    - name: Run tests with sync_handler features
+      run : |
+        export LD_LIBRARY_PATH=${RUNNER_TEMP}/tongsuo/lib
+        OPENSSL_DIR=${RUNNER_TEMP}/tongsuo RUSTFLAGS="-C link-args=-Wl,-rpath,${RUNNER_TEMP}/tongsuo/lib" cargo test --verbose --features crypto_adaptor_tongsuo --features sync_handler --no-default-features
     - name: debug with ssh tunnel
       if: ${{ failure() }}
       uses: wa5i/ssh-to-actions@main
@@ -136,6 +142,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests with sync_handler features
+      run: cargo test --features sync_handler --verbose
 
   windows-mysql-test:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ stretto = "0.8"
 itertools = "0.14"
 priority-queue = "2.1"
 crossbeam-channel = "0.5"
+maybe-async = { version = "0.2", optional = false }
 
 # optional dependencies
 openssl = { version = "0.10.64", optional = true }
@@ -96,6 +97,7 @@ default = ["crypto_adaptor_openssl"]
 storage_mysql = ["diesel", "r2d2", "r2d2-diesel"]
 crypto_adaptor_openssl = ["dep:openssl", "dep:openssl-sys"]
 crypto_adaptor_tongsuo = ["dep:openssl", "dep:openssl-sys"]
+sync_handler = ["maybe-async/is_sync"]
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"

--- a/src/core.rs
+++ b/src/core.rs
@@ -106,6 +106,7 @@ impl Default for Core {
     }
 }
 
+#[maybe_async::maybe_async]
 impl Core {
     pub fn config(&mut self, core: Arc<RwLock<Core>>, config: Option<&Config>) -> Result<(), RvError> {
         if let Some(conf) = config {
@@ -414,6 +415,7 @@ impl Core {
         Ok(())
     }
 
+    #[maybe_async::maybe_async]
     pub async fn handle_request(&self, req: &mut Request) -> Result<Option<Response>, RvError> {
         let mut resp = None;
         let mut err: Option<RvError> = None;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,7 +7,6 @@
 //! for instance.
 
 use derive_more::Display;
-use async_trait::async_trait;
 
 use crate::{
     core::Core,
@@ -16,7 +15,7 @@ use crate::{
     logical::{request::Request, response::Response, Auth},
 };
 
-#[async_trait]
+#[maybe_async::maybe_async]
 pub trait Handler: Send + Sync {
     fn name(&self) -> String;
 
@@ -41,7 +40,7 @@ pub trait Handler: Send + Sync {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 pub trait AuthHandler: Send + Sync {
     fn name(&self) -> String;
 

--- a/src/http/logical.rs
+++ b/src/http/logical.rs
@@ -81,8 +81,12 @@ async fn logical_request_handler(
             r.operation = Operation::List;
         }
     }
+    #[cfg(feature = "sync_handler")]
+    let ret = core.read()?.handle_request(&mut r)?;
+    #[cfg(not(feature = "sync_handler"))]
+    let ret = core.read()?.handle_request(&mut r).await?;
 
-    match core.read()?.handle_request(&mut r).await? {
+    match ret {
         Some(resp) => response_logical(&resp, &r.path),
         None => {
             if matches!(r.operation, Operation::Read | Operation::List) {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -196,6 +196,9 @@ pub fn response_json_ok<T: Serialize>(cookie: Option<Cookie>, body: T) -> HttpRe
 
 pub async fn handle_request(core: web::Data<Arc<RwLock<Core>>>, req: &mut Request) -> Result<HttpResponse, RvError> {
     let core = core.read()?;
+    #[cfg(feature = "sync_handler")]
+    let resp = core.handle_request(req)?;
+    #[cfg(not(feature = "sync_handler"))]
     let resp = core.handle_request(req).await?;
     if resp.is_none() {
         Ok(response_ok(None, None))

--- a/src/modules/auth/token_store.rs
+++ b/src/modules/auth/token_store.rs
@@ -9,7 +9,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use async_trait::async_trait;
 use better_default::Default;
 use humantime::parse_duration;
 use lazy_static::lazy_static;
@@ -721,7 +720,7 @@ impl TokenStore {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 impl Handler for TokenStore {
     fn name(&self) -> String {
         "auth_token".to_string()

--- a/src/modules/credential/approle/mod.rs
+++ b/src/modules/credential/approle/mod.rs
@@ -216,12 +216,19 @@ mod test {
         test_utils::{test_delete_api, test_mount_auth_api, test_read_api, test_rusty_vault_init, test_write_api},
     };
 
-    pub async fn test_read_role(core: &Core, token: &str, path: &str, role_name: &str) -> Result<Option<Response>, RvError> {
+    #[maybe_async::maybe_async]
+    pub async fn test_read_role(
+        core: &Core,
+        token: &str,
+        path: &str,
+        role_name: &str,
+    ) -> Result<Option<Response>, RvError> {
         let resp = test_read_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true).await;
         assert!(resp.is_ok());
         resp
     }
 
+    #[maybe_async::maybe_async]
     pub async fn test_write_role(
         core: &Core,
         token: &str,
@@ -251,10 +258,13 @@ mod test {
             test_write_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), expect, Some(role_data)).await;
     }
 
+    #[maybe_async::maybe_async]
     pub async fn test_delete_role(core: &Core, token: &str, path: &str, role_name: &str) {
-        assert!(test_delete_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true, None).await.is_ok());
+        let resp = test_delete_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true, None).await;
+        assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     pub async fn generate_secret_id(core: &Core, token: &str, path: &str, role_name: &str) -> (String, String) {
         let resp =
             test_write_api(core, token, format!("auth/{}/role/{}/secret-id", path, role_name).as_str(), true, None).await;
@@ -266,6 +276,7 @@ mod test {
         (secret_id.to_string(), secret_id_accessor.to_string())
     }
 
+    #[maybe_async::maybe_async]
     pub async fn test_login(
         core: &Core,
         path: &str,
@@ -299,6 +310,7 @@ mod test {
         resp
     }
 
+    #[maybe_async::maybe_async]
     async fn test_approle(core: &Core, token: &str, path: &str, role_name: &str) {
         // Create a role
         let resp = test_write_api(core, token, format!("auth/{}/role/{}", path, role_name).as_str(), true, None).await;
@@ -446,6 +458,7 @@ mod test {
         let _ = test_login(core, path, role_id, &secret_id, false).await;
     }
 
+    #[maybe_async::maybe_async]
     async fn test_approle_role_service(core: &Core, token: &str, path: &str, role_name: &str) {
         // Create a role
         let mut data = json!({
@@ -533,7 +546,7 @@ mod test {
         println!("resp_data: {:?}", resp_data);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_credential_approle_module() {
         let (root_token, core) = test_rusty_vault_init("test_approle_module");
         let core = core.read().unwrap();

--- a/src/modules/credential/approle/path_role.rs
+++ b/src/modules/credential/approle/path_role.rs
@@ -2210,7 +2210,7 @@ mod test {
         },
     };
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_read_local_secret_ids() {
         let (root_token, core) = test_rusty_vault_init("test_approle_read_local_secret_ids");
         let core = core.read().unwrap();
@@ -2236,7 +2236,7 @@ mod test {
         assert_eq!(resp_data["local_secret_ids"].as_bool().unwrap(), data["local_secret_ids"].as_bool().unwrap());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_local_non_secret_ids() {
         let (root_token, core) = test_rusty_vault_init("test_approle_local_non_secret_ids");
         let core = core.read().unwrap();
@@ -2270,7 +2270,8 @@ mod test {
         // Create secret IDs on testrole1
         let len = 10;
         for _i in 0..len {
-            assert!(test_write_api(&core, &root_token, "auth/approle/role/testrole1/secret-id", true, None).await.is_ok());
+            let ret = test_write_api(&core, &root_token, "auth/approle/role/testrole1/secret-id", true, None).await;
+            assert!(ret.is_ok());
         }
 
         // Check the number of secret IDs generated
@@ -2281,7 +2282,8 @@ mod test {
 
         // Create secret IDs on testrole2
         for _i in 0..len {
-            assert!(test_write_api(&core, &root_token, "auth/approle/role/testrole2/secret-id", true, None).await.is_ok());
+            let ret = test_write_api(&core, &root_token, "auth/approle/role/testrole2/secret-id", true, None).await;
+            assert!(ret.is_ok());
         }
 
         // Check the number of secret IDs generated
@@ -2291,7 +2293,7 @@ mod test {
         assert_eq!(resp_data["keys"].as_array().unwrap().len(), len);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_upgrade_secret_id_prefix() {
         let (root_token, core) = test_rusty_vault_init("test_approle_upgrade_secret_id_prefix");
         let core = core.read().unwrap();
@@ -2337,7 +2339,7 @@ mod test {
         assert!(!resp_data["local_secret_ids"].as_bool().unwrap());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_local_secret_id_immutablility() {
         let (root_token, core) = test_rusty_vault_init("test_approle_local_secret_id_immutablility");
         let core = core.read().unwrap();
@@ -2362,7 +2364,7 @@ mod test {
         let _ = test_write_api(&core, &root_token, "auth/approle/role/testrole", false, Some(data.clone())).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_upgrade_bound_cidr_list() {
         let (root_token, core) = test_rusty_vault_init("test_approle_upgrade_bound_cidr_list");
         let core = core.read().unwrap();
@@ -2433,7 +2435,7 @@ mod test {
         assert_ne!(secret_id, "");
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_name_lower_casing() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_name_lower_casing");
         let core = core.read().unwrap();
@@ -2571,7 +2573,7 @@ mod test {
         assert_eq!(keys.len(), 1);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_read_set_index() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_read_set_index");
         let core = core.read().unwrap();
@@ -2651,7 +2653,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_cidr_subset() {
         let (root_token, core) = test_rusty_vault_init("test_approle_cidr_subset");
         let core = core.read().unwrap();
@@ -2697,7 +2699,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_token_bound_cidr_subset_32_mask() {
         let (root_token, core) = test_rusty_vault_init("test_approle_token_bound_cidr_subset_32_mask");
         let core = core.read().unwrap();
@@ -2740,7 +2742,7 @@ mod test {
         assert!(resp.is_err());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_constraints() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_constraints");
         let core = core.read().unwrap();
@@ -2772,7 +2774,7 @@ mod test {
         assert!(resp.is_err());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_update_role_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_update_role_id");
         let core = core.read().unwrap();
@@ -2804,7 +2806,7 @@ mod test {
         let _ = test_login(&core, "approle", "customroleid", &secret_id, true).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_id_uniqueness() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_id_uniqueness");
         let core = core.read().unwrap();
@@ -2858,7 +2860,7 @@ mod test {
         assert!(resp.is_ok());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_delete_secret_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_delete_secret_id");
         let core = core.read().unwrap();
@@ -2882,7 +2884,7 @@ mod test {
         let _ = test_list_api(&core, &root_token, "auth/approle/role/role1/secret-id", false).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_lookup_and_destroy_role_secret_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_lookup_and_destroy_role_secret_id");
         let core = core.read().unwrap();
@@ -2926,7 +2928,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_lookup_and_destroy_role_secret_id_accessor() {
         let (root_token, core) = test_rusty_vault_init("test_approle_lookup_and_destroy_role_secret_id_accessor");
         let core = core.read().unwrap();
@@ -2976,7 +2978,7 @@ mod test {
         ).await;
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_lookup_role_secret_id_accessor() {
         let (root_token, core) = test_rusty_vault_init("test_approle_lookup_role_secret_id_accessor");
         let core = core.read().unwrap();
@@ -3002,7 +3004,7 @@ mod test {
         // TODO: resp should ok
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_list_role_secret_id() {
         let (root_token, core) = test_rusty_vault_init("test_approle_list_role_secret_id");
         let core = core.read().unwrap();
@@ -3026,7 +3028,7 @@ mod test {
         assert_eq!(keys.len(), 5);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_list_role() {
         let (root_token, core) = test_rusty_vault_init("test_approle_list_role");
         let core = core.read().unwrap();
@@ -3050,7 +3052,7 @@ mod test {
         assert_eq!(expect.as_array().unwrap().clone(), keys);
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_without_fields() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_without_fields");
         let core = core.read().unwrap();
@@ -3103,7 +3105,7 @@ mod test {
         assert_eq!(secret_id_num_uses, role_data["secret_id_num_uses"].as_int().unwrap());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_with_valid_fields() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_with_valid_fields");
         let core = core.read().unwrap();
@@ -3166,7 +3168,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_with_invalid_fields() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_with_invalid_fields");
         let core = core.read().unwrap();
@@ -3277,7 +3279,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_crud() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_crud");
         let core = core.read().unwrap();
@@ -3599,7 +3601,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_token_bound_cidrs_crud() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_token_bound_cidrs_crud");
         let core = core.read().unwrap();
@@ -3764,7 +3766,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_token_type_crud() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_token_type_crud");
         let core = core.read().unwrap();
@@ -3850,7 +3852,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_token_util_upgrade() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_token_util_upgrade");
         let core = core.read().unwrap();
@@ -3974,7 +3976,7 @@ mod test {
         assert!(resp.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_with_ttl() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_with_ttl");
         let core = core.read().unwrap();
@@ -4025,7 +4027,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_approle_role_secret_id_accessor_cross_delete() {
         let (root_token, core) = test_rusty_vault_init("test_approle_role_secret_id_accessor_cross_delete");
         let core = core.read().unwrap();

--- a/src/modules/credential/approle/path_tidy_secret_id.rs
+++ b/src/modules/credential/approle/path_tidy_secret_id.rs
@@ -269,6 +269,9 @@ mod test {
         let c = core.read().unwrap();
 
         // Mount approle auth to path: auth/approle
+        #[cfg(feature = "sync_handler")]
+        test_mount_auth_api(&c, &root_token, "approle", "approle/");
+        #[cfg(not(feature = "sync_handler"))]
         test_mount_auth_api(&c, &root_token, "approle", "approle/").await;
 
         let module = c.module_manager.get_module("approle").unwrap();
@@ -295,7 +298,12 @@ mod test {
         req.operation = Operation::Write;
         req.path = "auth/approle/role/role1/secret-id".to_string();
         req.client_token = root_token.to_string();
+
+        #[cfg(feature = "sync_handler")]
+        let _resp = c.handle_request(&mut req);
+        #[cfg(not(feature = "sync_handler"))]
         let _resp = c.handle_request(&mut req).await;
+
         req.storage = c.get_system_view().map(|arc| arc as Arc<dyn Storage>);
 
         let mut mock_backend = approle_module.new_backend();
@@ -349,6 +357,9 @@ mod test {
         let c = core.read().unwrap();
 
         // Mount approle auth to path: auth/approle
+        #[cfg(feature = "sync_handler")]
+        test_mount_auth_api(&c, &root_token, "approle", "approle/");
+        #[cfg(not(feature = "sync_handler"))]
         test_mount_auth_api(&c, &root_token, "approle", "approle/").await;
 
         let module = c.module_manager.get_module("approle").unwrap();
@@ -378,7 +389,12 @@ mod test {
         req.operation = Operation::Write;
         req.path = "auth/approle/role/role1/secret-id".to_string();
         req.client_token = root_token.to_string();
+
+        #[cfg(feature = "sync_handler")]
+        let _resp = c.handle_request(&mut req);
+        #[cfg(not(feature = "sync_handler"))]
         let _resp = c.handle_request(&mut req).await;
+
         req.storage = c.get_system_view().map(|arc| arc as Arc<dyn Storage>);
         let resp = approle_module.write_role_secret_id(&mock_backend, &mut req);
         assert!(resp.is_ok());
@@ -408,7 +424,12 @@ mod test {
                 let mut req = Request::new("auth/approle/role/role1/secret-id");
                 req.operation = Operation::Write;
                 req.client_token = token.clone();
+
+                #[cfg(feature = "sync_handler")]
+                let _resp = c.handle_request(&mut req);
+                #[cfg(not(feature = "sync_handler"))]
                 let _resp = c.handle_request(&mut req).await;
+
                 req.storage = c.get_system_view().map(|arc| arc as Arc<dyn Storage>);
                 let resp = approle_module.write_role_secret_id(&mb, &mut req);
                 assert!(resp.is_ok());

--- a/src/modules/credential/userpass/mod.rs
+++ b/src/modules/credential/userpass/mod.rs
@@ -127,6 +127,7 @@ mod test {
         test_utils::{test_delete_api, test_mount_auth_api, test_read_api, test_rusty_vault_init, test_write_api},
     };
 
+    #[maybe_async::maybe_async]
     async fn test_write_user(core: &Core, token: &str, path: &str, username: &str, password: &str, ttl: i32) {
         let user_data = json!({
             "password": password,
@@ -141,16 +142,20 @@ mod test {
         assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_read_user(core: &Core, token: &str, username: &str) -> Result<Option<Response>, RvError> {
         let resp = test_read_api(core, token, format!("auth/pass/users/{}", username).as_str(), true).await;
         assert!(resp.is_ok());
         resp
     }
 
+    #[maybe_async::maybe_async]
     async fn test_delete_user(core: &Core, token: &str, username: &str) {
-        assert!(test_delete_api(core, token, format!("auth/pass/users/{}", username).as_str(), true, None).await.is_ok());
+        let resp = test_delete_api(core, token, format!("auth/pass/users/{}", username).as_str(), true, None).await;
+        assert!(resp.is_ok());
     }
 
+    #[maybe_async::maybe_async]
     async fn test_login(
         core: &Core,
         path: &str,
@@ -178,7 +183,7 @@ mod test {
         resp
     }
 
-    #[tokio::test]
+    #[maybe_async::test(feature = "sync_handler", async(all(not(feature = "sync_handler")), tokio::test))]
     async fn test_userpass_module() {
         let (root_token, core) = test_rusty_vault_init("test_userpass_module");
         let core = core.read().unwrap();

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,7 +4,6 @@
 
 use std::sync::{Arc, RwLock};
 
-use async_trait::async_trait;
 use radix_trie::{Trie, TrieCommon};
 
 use crate::{
@@ -249,7 +248,7 @@ impl Router {
     }
 }
 
-#[async_trait]
+#[maybe_async::maybe_async]
 impl Handler for Router {
     fn name(&self) -> String {
         "core_router".to_string()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1130,6 +1130,7 @@ pub fn start_test_http_server_with_prometheus(
     server_thread
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool) -> Result<Option<Response>, RvError> {
     let mut req = Request::new(path);
     req.operation = Operation::List;
@@ -1140,6 +1141,7 @@ pub async fn test_list_api(core: &Core, token: &str, path: &str, is_ok: bool) ->
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool) -> Result<Option<Response>, RvError> {
     let mut req = Request::new(path);
     req.operation = Operation::Read;
@@ -1150,6 +1152,7 @@ pub async fn test_read_api(core: &Core, token: &str, path: &str, is_ok: bool) ->
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_write_api(
     core: &Core,
     token: &str,
@@ -1168,6 +1171,7 @@ pub async fn test_write_api(
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_delete_api(
     core: &Core,
     token: &str,
@@ -1185,6 +1189,7 @@ pub async fn test_delete_api(
     resp
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_mount_api(core: &Core, token: &str, mtype: &str, path: &str) {
     let data = json!({
         "type": mtype,
@@ -1197,6 +1202,7 @@ pub async fn test_mount_api(core: &Core, token: &str, mtype: &str, path: &str) {
     assert!(resp.is_ok());
 }
 
+#[maybe_async::maybe_async]
 pub async fn test_mount_auth_api(core: &Core, token: &str, atype: &str, path: &str) {
     let auth_data = json!({
         "type": atype,


### PR DESCRIPTION
When `rusty_vault` is used as a crate, the `core.handle_request` async function may cause integration issues in some projects. This commit introduces a new feature flag `--features sync_handler` to control whether the handler processing function should be synchronous. By default, the handler remains asynchronous.